### PR TITLE
some cmake tweaks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -498,6 +498,9 @@ if(HI_BUILD_TESTS)
             ${CMAKE_CURRENT_BINARY_DIR}
     )
 
+    set_property(GLOBAL PROPERTY USE_FOLDERS ON)
+    set_target_properties(gtest      PROPERTIES FOLDER extern)
+    set_target_properties(gtest_main PROPERTIES FOLDER extern)
 endif()
 
 #-------------------------------------------------------------------

--- a/CMakeOverride.txt
+++ b/CMakeOverride.txt
@@ -1,6 +1,7 @@
 
 # By default cmake does not make optimized binaries when building "RelWithDebInfo" using the MSVC compiler.
 # It will only make optimized binaries when making a "Release" build, however those don't have debugging symbols.
+# Referencing: https://gitlab.kitware.com/cmake/cmake/-/issues/20812
 #
 # This CMakeOverride.txt will change the default compiler options for the "RelWithDebInfo" to make a fully
 # optimized executable like when building with "Release" but with included debugging symbols.
@@ -88,7 +89,7 @@ elseif (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
   #
   set(CMAKE_CXX_FLAGS_RELWITHDEBINFO_INIT           "-Zi -O2 -Ob3 -GL -DNDEBUG")
   set(CMAKE_C_FLAGS_RELWITHDEBINFO_INIT             "-Zi -O2 -Ob3 -GL -DNDEBUG")
-  set(CMAKE_EXE_LINKER_FLAGS_RELWITHDEBINFO_INIT    "-INCREMENTAL:NO -LTCG -debug")
-  set(CMAKE_MODULE_LINKER_FLAGS_RELWITHDEBINFO_INIT "-INCREMENTAL:NO -LTCG -debug")
-  set(CMAKE_SHARED_LINKER_FLAGS_RELWITHDEBINFO_INIT "-INCREMENTAL:NO -LTCG -debug")
+  set(CMAKE_EXE_LINKER_FLAGS_RELWITHDEBINFO_INIT    "-INCREMENTAL:NO -LTCG -DEBUG:FASTLINK")
+  set(CMAKE_MODULE_LINKER_FLAGS_RELWITHDEBINFO_INIT "-INCREMENTAL:NO -LTCG -DEBUG:FASTLINK")
+  set(CMAKE_SHARED_LINKER_FLAGS_RELWITHDEBINFO_INIT "-INCREMENTAL:NO -LTCG -DEBUG:FASTLINK")
 endif()

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -10,15 +10,21 @@
                 "CMAKE_INSTALL_PREFIX": "$env{USERPROFILE}\\CMakeBuilds\\${sourceDirName}\\install\\${presetName}",
                 "CMAKE_VERBOSE_MAKEFILE": "ON",
                 "VCPKG_TARGET_TRIPLET": "x64-windows-static",
-                "BUILD_SHARED_LIBS": "OFF"
+                "BUILD_SHARED_LIBS": "OFF",
+                "CMAKE_CXX_COMPILER": "cl"
             },
             "architecture": {
                 "value": "x64",
                 "strategy": "external"
             },
+            "toolset": {
+              "value": "v143,host=x64",
+              "strategy": "external"
+            },
             "vendor": {
                 "microsoft.com/VisualStudioSettings/CMake/1.0": {
-                    "hostOS": [ "Windows" ]
+                    "hostOS": [ "Windows" ],
+                    "intelliSenseMode": "windows-msvc-x64"
                 }
             }
         },
@@ -27,17 +33,7 @@
             "inherits": "x64-Windows",
             "cacheVariables": {
                 "CMAKE_BUILD_TYPE": "Debug",
-                "CMAKE_VERBOSE_MAKEFILE": "ON",
-                "CMAKE_CXX_COMPILER": "cl"
-            },
-            "architecture": {
-                "value": "x64",
-                "strategy": "external"
-            },
-            "vendor": {
-                "microsoft.com/VisualStudioSettings/CMake/1.0": {
-                    "intelliSenseMode": "windows-msvc-x64"
-                }
+                "CMAKE_VERBOSE_MAKEFILE": "ON"
             }
         },
         {
@@ -60,13 +56,7 @@
             "inherits": "x64-Windows",
             "cacheVariables": {
                 "CMAKE_BUILD_TYPE": "RelWithDebInfo",
-                "CMAKE_CXX_COMPILER": "cl",
                 "HI_BUILD_PCH": "OFF"
-            },
-            "vendor": {
-                "microsoft.com/VisualStudioSettings/CMake/1.0": {
-                    "intelliSenseMode": "windows-msvc-x64"
-                }
             }
         },
         {

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -15,3 +15,8 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
 	target_compile_options(embed_static_resource PRIVATE -DUNICODE -D_UNICODE -DNOMINMAX -D_CRT_SECURE_NO_WARNINGS)
 endif()
 
+# disable debug info (do not create PDB)
+target_compile_options(embed_static_resource PRIVATE
+    "$<$<CONFIG:Release,RelWithDebInfo>:-DEBUG:NONE>")
+target_link_options(embed_static_resource PRIVATE
+    "$<$<CONFIG:Release,RelWithDebInfo>:-DEBUG:NONE>")


### PR DESCRIPTION
Changes:
- `CMakeLists.txt`: place gtest lib into folder "extern"
- `tools/CMakeLists.txt`: disable creation of PDB file for Release&RelWithDebugInfo
- `CMakeOverRide.txt`: 
    - add reference on the initial issue 
    - let RelWithDebugInfo use DEBUG:FASTLINK to speed up linking
- `CMakePresets.json`: fix inheritance and fix using the x86 host by default by setting toolset and host=x64
     - this fixes restarting the linker, which formerly resulted in the following message: [build] LINK : the 32-bit linker (C:\...\2022\Preview\VC\Tools\MSVC\1433~1.316\bin\Hostx86\x64\link.exe) failed to do memory mapped file I/O on `hikogui.lib' and is going to restart linking with a 64-bit linker for better throughput