### PR TITLE
remove window argument from widgets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,6 +52,9 @@ project(${HI_LIB_NAME} VERSION ${HI_LIB_VERSION} LANGUAGES ${LANGUAGES})
 include(AddShader)
 include(ShowBuildTargetProperties)
 include(FetchContent)
+
+# disable adding CTest build targets like "NightlyStart" (before ctest include)
+set_property(GLOBAL PROPERTY CTEST_TARGETS_ADDED 1)
 include(CTest)
 
 #-------------------------------------------------------------------
@@ -71,7 +74,7 @@ if(BUILD_TESTING)
     add_executable(hikogui_tests)
     # PRE_TEST delays test discovery until just prior to test execution
     gtest_discover_tests(hikogui_tests DISCOVERY_MODE PRE_TEST)
-   
+
     set_property(GLOBAL PROPERTY USE_FOLDERS ON)
     set_target_properties(gtest      PROPERTIES FOLDER extern)
     set_target_properties(gtest_main PROPERTIES FOLDER extern)
@@ -438,13 +441,13 @@ install(FILES
 if (BUILD_TESTING)
     target_link_libraries(hikogui_tests PRIVATE gtest_main hikogui)
     target_include_directories(hikogui_tests PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
-    
-    
+
+
     add_custom_target(hikogui_tests_resources
         COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_SOURCE_DIR}/tests/data ${CMAKE_CURRENT_BINARY_DIR}
     )
     add_dependencies(hikogui_tests hikogui_tests_resources)
-    
+
     #-------------------------------------------------------------------
     # Installation Rules: hikogui_tests                      (executable)
     #-------------------------------------------------------------------

--- a/docs/how_to/how_to_draw.md
+++ b/docs/how_to/how_to_draw.md
@@ -138,7 +138,7 @@ Here we load the `mars3.png` file from a resource directory from the constructor
 
 ```cpp
 drawing_widget(hi::gui_window &window, hi::widget *parent) noexcept :
-    widget(window, parent), _image(hi::URL("resource:mars3.png")) {}
+    widget(parent), _image(hi::URL("resource:mars3.png")) {}
 ```
 
 During `set_constraints()`  we try to construct a `hi::paged_image`. In the

--- a/examples/custom_widgets/custom_widget_command_example.cpp
+++ b/examples/custom_widgets/custom_widget_command_example.cpp
@@ -16,7 +16,7 @@ public:
 
     // Every constructor of a widget starts with a `window` and `parent` argument.
     // In most cases these are automatically filled in when calling a container widget's `make_widget()` function.
-    command_widget(hi::gui_window& window, hi::widget *parent) noexcept : hi::widget(window, parent)
+    command_widget(hi::widget *parent) noexcept : hi::widget(parent)
     {
         // To visually show the change in value the widget needs to be redrawn.
         _value_cbt = value.subscribe([&](auto...) {

--- a/examples/custom_widgets/custom_widget_drawing_example.cpp
+++ b/examples/custom_widgets/custom_widget_drawing_example.cpp
@@ -85,8 +85,8 @@ public:
 
     // Every constructor of a widget starts with a `window` and `parent` argument.
     // In most cases these are automatically filled in when calling a container widget's `make_widget()` function.
-    drawing_widget(hi::gui_window& window, hi::widget *parent) noexcept :
-        widget(window, parent), _image(hi::URL("resource:mars3.png"))
+    drawing_widget(hi::widget *parent) noexcept :
+        widget(parent), _image(hi::URL("resource:mars3.png"))
     {
         // clang-format off
         _drawing_cbt = this->drawing.subscribe([&](auto...){ request_redraw(); });
@@ -111,7 +111,7 @@ public:
         _layout = {};
 
         if (_image_was_modified.exchange(false)) {
-            if (not(_image_backing = hi::paged_image{window.surface.get(), _image})) {
+            if (not(_image_backing = hi::paged_image{window().surface.get(), _image})) {
                 // Could not get an image, retry.
                 _image_was_modified = true;
                 hi_request_reconstrain("drawing_widget::set_constraints() could not get backing image.");

--- a/examples/custom_widgets/custom_widget_with_child_example.cpp
+++ b/examples/custom_widgets/custom_widget_with_child_example.cpp
@@ -14,12 +14,12 @@ public:
     // Every constructor of a widget starts with a `window` and `parent` argument.
     // In most cases these are automatically filled in when calling a container widget's `make_widget()` function.
     template<typename Label>
-    widget_with_child(hi::gui_window& window, hi::widget *parent, Label&& label) noexcept : widget(window, parent)
+    widget_with_child(hi::widget *parent, Label&& label) noexcept : widget(parent)
     {
         // Our child widget is a `label_widget` which requires a label to be passed as an third argument.
         // We use a templated argument to forward the label into the `label_widget`.
         _label_widget =
-            std::make_unique<hi::label_widget>(window, this, std::forward<Label>(label), hi::alignment::middle_center());
+            std::make_unique<hi::label_widget>(this, std::forward<Label>(label), hi::alignment::middle_center());
     }
 
     // The set_constraints() function is called when the window is first initialized,

--- a/examples/custom_widgets/minimum_custom_widget_example.cpp
+++ b/examples/custom_widgets/minimum_custom_widget_example.cpp
@@ -12,7 +12,7 @@ class minimum_widget : public hi::widget {
 public:
     // Every constructor of a widget starts with a `window` and `parent` argument.
     // In most cases these are automatically filled in when calling a container widget's `make_widget()` function.
-    minimum_widget(hi::gui_window& window, hi::widget *parent) noexcept : widget(window, parent) {}
+    minimum_widget(hi::widget *parent) noexcept : widget(parent) {}
 
     // The set_constraints() function is called when the window is first initialized,
     // or when a widget wants to change its constraints.

--- a/examples/hikogui_demo/src/main.cpp
+++ b/examples/hikogui_demo/src/main.cpp
@@ -87,7 +87,7 @@ hi::scoped_task<> init_theme_tab(hi::grid_widget& grid, my_preferences& preferen
     hi::observer<std::vector<std::pair<std::string, hi::label>>> theme_list;
 
     {
-        auto& theme_book = *grid.window.gui.theme_book;
+        auto& theme_book = *grid.window().gui.theme_book;
         auto proxy = theme_list.copy();
         for (hilet& name : theme_book.theme_names()) {
             proxy->emplace_back(name, tr{name});

--- a/examples/vulkan/triangle/main.cpp
+++ b/examples/vulkan/triangle/main.cpp
@@ -20,13 +20,13 @@ class triangle_widget : public hi::widget, public hi::gfx_surface_delegate_vulka
 public:
     // Every constructor of a widget starts with a `window` and `parent` argument.
     // In most cases these are automatically filled in when calling a container widget's `make_widget()` function.
-    triangle_widget(hi::gui_window& window, hi::widget *parent) noexcept : widget(window, parent) {
-        window.surface->add_delegate(this);
+    triangle_widget(hi::widget *parent) noexcept : widget(parent) {
+        window().surface->add_delegate(this);
     }
 
     ~triangle_widget()
     {
-        window.surface->remove_delegate(this);
+        window().surface->remove_delegate(this);
     }
 
     // The set_constraints() function is called when the window is first initialized,
@@ -71,7 +71,7 @@ public:
     // The `draw()` function is called when all or part of the window requires redrawing.
     // This may happen when showing the window for the first time, when the operating-system
     // requests a (partial) redraw, or when a widget requests a redraw of itself.
-    // 
+    //
     // This draw() function only draws the GUI part of the widget, there is another draw() function
     // that will draw the 3D part.
     void draw(hi::draw_context const& context) noexcept override
@@ -104,7 +104,7 @@ public:
         //  - the semaphores when to start drawing, and when the drawing is finished.
         //  - The render-area, which is like the dirty-rectangle that needs to be redrawn.
         //  - View-port the part of the frame buffer that matches this widget's rectangle.
-        // 
+        //
         // The "vulkan graphics engine" is responsible to not drawn outside the neither
         // the render-area nor outside the view-port.
         _triangle_example->render(

--- a/src/hikogui/GUI/gui_window.cpp
+++ b/src/hikogui/GUI/gui_window.cpp
@@ -38,7 +38,7 @@ void gui_window::init()
     // and therefor should not have a lock.
     hi_axiom(loop::main().on_thread());
 
-    widget = std::make_unique<window_widget>(*this, title);
+    widget = std::make_unique<window_widget>(this, title);
 
     // Execute a constraint check to determine initial window size.
     theme = gui.theme_book->find(*gui.selected_theme, os_settings::theme_mode()).transform(dpi);

--- a/src/hikogui/GUI/gui_window.hpp
+++ b/src/hikogui/GUI/gui_window.hpp
@@ -103,9 +103,9 @@ public:
     virtual ~gui_window();
 
     gui_window(gui_window const&) = delete;
-    gui_window& operator=(gui_window const&) = delete;
+    //gui_window& operator=(gui_window const&) = delete;
     gui_window(gui_window&&) = delete;
-    gui_window& operator=(gui_window&&) = delete;
+    //gui_window& operator=(gui_window&&) = delete;
 
     /** 2 phase constructor.
      * Must be called directly after the constructor on the same thread,

--- a/src/hikogui/widgets/abstract_button_widget.cpp
+++ b/src/hikogui/widgets/abstract_button_widget.cpp
@@ -10,16 +10,15 @@
 namespace hi::inline v1 {
 
 abstract_button_widget::abstract_button_widget(
-    gui_window& window,
     widget *parent,
     std::shared_ptr<delegate_type> delegate) noexcept :
-    super(window, parent), delegate(std::move(delegate))
+    super(parent), delegate(std::move(delegate))
 {
     hi_assert_not_null(this->delegate);
 
-    _on_label_widget = std::make_unique<label_widget>(window, this, on_label, alignment, text_style);
-    _off_label_widget = std::make_unique<label_widget>(window, this, off_label, alignment, text_style);
-    _other_label_widget = std::make_unique<label_widget>(window, this, other_label, alignment, text_style);
+    _on_label_widget = std::make_unique<label_widget>(this, on_label, alignment, text_style);
+    _off_label_widget = std::make_unique<label_widget>(this, off_label, alignment, text_style);
+    _other_label_widget = std::make_unique<label_widget>(this, other_label, alignment, text_style);
     _delegate_cbt = this->delegate->subscribe([&] {
         request_relayout();
     });

--- a/src/hikogui/widgets/abstract_button_widget.hpp
+++ b/src/hikogui/widgets/abstract_button_widget.hpp
@@ -62,7 +62,7 @@ public:
 
     ~abstract_button_widget();
 
-    abstract_button_widget(gui_window& window, widget *parent, std::shared_ptr<delegate_type> delegate) noexcept;
+    abstract_button_widget(widget *parent, std::shared_ptr<delegate_type> delegate) noexcept;
 
     /** Get the current state of the button.
      * @return The state of the button: on / off / other.

--- a/src/hikogui/widgets/audio_device_widget.cpp
+++ b/src/hikogui/widgets/audio_device_widget.cpp
@@ -9,10 +9,10 @@ namespace hi::inline v1 {
 
 audio_device_widget::~audio_device_widget() {}
 
-audio_device_widget::audio_device_widget(gui_window& window, widget *parent, hi::audio_system& audio_system) noexcept :
-    super(window, parent), _audio_system(&audio_system)
+audio_device_widget::audio_device_widget(widget *parent, hi::audio_system& audio_system) noexcept :
+    super(parent), _audio_system(&audio_system)
 {
-    _grid_widget = std::make_unique<grid_widget>(window, this);
+    _grid_widget = std::make_unique<grid_widget>(this);
     _device_selection_widget = &_grid_widget->make_widget<selection_widget>("A1", device_id, _device_list);
 
     _sync_device_list_task = sync_device_list();

--- a/src/hikogui/widgets/audio_device_widget.hpp
+++ b/src/hikogui/widgets/audio_device_widget.hpp
@@ -39,7 +39,7 @@ public:
 
     virtual ~audio_device_widget();
 
-    audio_device_widget(gui_window& window, widget *parent, hi::audio_system& audio_system) noexcept;
+    audio_device_widget(widget *parent, hi::audio_system& audio_system) noexcept;
 
     /// @privatesection
     [[nodiscard]] generator<widget *> children() const noexcept override;

--- a/src/hikogui/widgets/checkbox_widget.hpp
+++ b/src/hikogui/widgets/checkbox_widget.hpp
@@ -46,7 +46,6 @@ public:
 
     /** Construct a checkbox widget.
      *
-     * @param window The window that this widget belongs to.
      * @param parent The parent widget that owns this checkbox widget.
      * @param delegate The delegate to use to manage the state of the checkbox button.
      * @param attributes Different attributes used to configure the label's on the checkbox button:
@@ -55,11 +54,10 @@ public:
      *                   the labels are shown in on-state, off-state and other-state in that order.
      */
     checkbox_widget(
-        gui_window& window,
         widget *parent,
         std::shared_ptr<delegate_type> delegate,
         button_widget_attribute auto&&...attributes) noexcept :
-        super(window, parent, std::move(delegate))
+        super(parent, std::move(delegate))
     {
         alignment = alignment::top_left();
         set_attributes<0>(hi_forward(attributes)...);
@@ -68,7 +66,6 @@ public:
     /** Construct a checkbox widget with a default button delegate.
      *
      * @see default_button_delegate
-     * @param window The window that this widget belongs to.
      * @param parent The parent widget that owns this checkbox widget.
      * @param value The value or `observer` value which represents the state of the checkbox.
      * @param attributes Different attributes used to configure the label's on the checkbox button:
@@ -77,18 +74,16 @@ public:
      *                   the labels are shown in on-state, off-state and other-state in that order.
      */
     checkbox_widget(
-        gui_window& window,
         widget *parent,
         different_from<std::shared_ptr<delegate_type>> auto&& value,
         button_widget_attribute auto&&...attributes) noexcept requires requires
     {
         make_default_toggle_button_delegate(hi_forward(value));
-    } : checkbox_widget(window, parent, make_default_toggle_button_delegate(hi_forward(value)), hi_forward(attributes)...) {}
+    } : checkbox_widget(parent, make_default_toggle_button_delegate(hi_forward(value)), hi_forward(attributes)...) {}
 
     /** Construct a checkbox widget with a default button delegate.
      *
      * @see default_button_delegate
-     * @param window The window that this widget belongs to.
      * @param parent The parent widget that owns this checkbox widget.
      * @param value The value or `observer` value which represents the state of the checkbox.
      * @param on_value The on-value. This value is used to determine which value yields an 'on' state.
@@ -101,13 +96,12 @@ public:
         different_from<std::shared_ptr<delegate_type>> Value,
         forward_of<observer<observer_decay_t<Value>>> OnValue,
         button_widget_attribute... Attributes>
-    checkbox_widget(gui_window& window, widget *parent, Value&& value, OnValue&& on_value, Attributes&&...attributes) noexcept
+    checkbox_widget(widget *parent, Value&& value, OnValue&& on_value, Attributes&&...attributes) noexcept
         requires requires
     {
         make_default_toggle_button_delegate(hi_forward(value), hi_forward(on_value));
     } :
         checkbox_widget(
-            window,
             parent,
             make_default_toggle_button_delegate(hi_forward(value), hi_forward(on_value)),
             hi_forward(attributes)...)
@@ -117,7 +111,6 @@ public:
     /** Construct a checkbox widget with a default button delegate.
      *
      * @see default_button_delegate
-     * @param window The window that this widget belongs to.
      * @param parent The parent widget that owns this checkbox widget.
      * @param value The value or `observer` value which represents the state of the checkbox.
      * @param on_value The on-value. This value is used to determine which value yields an 'on' state.
@@ -133,7 +126,6 @@ public:
         forward_of<observer<observer_decay_t<Value>>> OffValue,
         button_widget_attribute... Attributes>
     checkbox_widget(
-        gui_window& window,
         widget *parent,
         Value&& value,
         OnValue&& on_value,
@@ -143,7 +135,6 @@ public:
         make_default_toggle_button_delegate(hi_forward(value), hi_forward(on_value), hi_forward(off_value));
     } :
         checkbox_widget(
-            window,
             parent,
             make_default_toggle_button_delegate(hi_forward(value), hi_forward(on_value), hi_forward(off_value)),
             hi_forward(attributes)...)

--- a/src/hikogui/widgets/grid_widget.cpp
+++ b/src/hikogui/widgets/grid_widget.cpp
@@ -9,7 +9,7 @@
 
 namespace hi::inline v1 {
 
-grid_widget::grid_widget(gui_window& window, widget *parent) noexcept : widget(window, parent)
+grid_widget::grid_widget(widget *parent) noexcept : widget(parent)
 {
     hi_axiom(loop::main().on_thread());
 

--- a/src/hikogui/widgets/grid_widget.hpp
+++ b/src/hikogui/widgets/grid_widget.hpp
@@ -45,10 +45,9 @@ public:
 
     /** Constructs an empty grid widget.
      *
-     * @param window The window.
      * @param parent The parent widget.
      */
-    grid_widget(gui_window& window, widget *parent) noexcept;
+    grid_widget(widget *parent) noexcept;
 
     /** Add a widget directly to this grid-widget.
      *
@@ -64,7 +63,7 @@ public:
     Widget&
     make_widget(std::size_t column_first, std::size_t row_first, std::size_t column_last, std::size_t row_last, Args&&...args)
     {
-        auto tmp = std::make_unique<Widget>(window, this, std::forward<Args>(args)...);
+        auto tmp = std::make_unique<Widget>(this, std::forward<Args>(args)...);
         return static_cast<Widget&>(add_widget(column_first, row_first, column_last, row_last, std::move(tmp)));
     }
 
@@ -79,7 +78,7 @@ public:
     template<typename Widget, typename... Args>
     Widget& make_widget(std::size_t column, std::size_t row, Args&&...args)
     {
-        auto tmp = std::make_unique<Widget>(window, this, std::forward<Args>(args)...);
+        auto tmp = std::make_unique<Widget>(this, std::forward<Args>(args)...);
         return static_cast<Widget&>(add_widget(column, row, column + 1, row + 1, std::move(tmp)));
     }
 

--- a/src/hikogui/widgets/icon_widget.cpp
+++ b/src/hikogui/widgets/icon_widget.cpp
@@ -9,7 +9,7 @@
 
 namespace hi::inline v1 {
 
-icon_widget::icon_widget(gui_window &window, widget *parent) noexcept : super(window, parent)
+icon_widget::icon_widget(widget *parent) noexcept : super(parent)
 {
     _icon_cbt = icon.subscribe([this](auto...) {
         _icon_has_modified = true;

--- a/src/hikogui/widgets/icon_widget.hpp
+++ b/src/hikogui/widgets/icon_widget.hpp
@@ -45,8 +45,8 @@ public:
      */
     observer<alignment> alignment = hi::alignment::middle_center();
 
-    icon_widget(gui_window& window, widget *parent, icon_widget_attribute auto&&...attributes) noexcept :
-        icon_widget(window, parent)
+    icon_widget(widget *parent, icon_widget_attribute auto&&...attributes) noexcept :
+        icon_widget(parent)
     {
         set_attributes(hi_forward(attributes)...);
     }
@@ -83,7 +83,7 @@ private:
     extent2 _icon_size;
     aarectangle _icon_rectangle;
 
-    icon_widget(gui_window& window, widget *parent) noexcept;
+    icon_widget(widget *parent) noexcept;
 };
 
 }} // namespace hi::v1

--- a/src/hikogui/widgets/label_widget.cpp
+++ b/src/hikogui/widgets/label_widget.cpp
@@ -6,13 +6,13 @@
 
 namespace hi::inline v1 {
 
-label_widget::label_widget(gui_window& window, widget *parent) noexcept : super(window, parent)
+label_widget::label_widget(widget *parent) noexcept : super(parent)
 {
     mode = widget_mode::select;
 
-    _icon_widget = std::make_unique<icon_widget>(window, this, label.get<"icon">());
+    _icon_widget = std::make_unique<icon_widget>(this, label.get<"icon">());
     _icon_widget->alignment = alignment;
-    _text_widget = std::make_unique<text_widget>(window, this, label.get<"text">());
+    _text_widget = std::make_unique<text_widget>(this, label.get<"text">());
     _text_widget->alignment = alignment;
     _text_widget->text_style = text_style;
     _text_widget->mode = mode;

--- a/src/hikogui/widgets/label_widget.hpp
+++ b/src/hikogui/widgets/label_widget.hpp
@@ -73,13 +73,12 @@ public:
     /** Construct a label widget.
      *
      * @see `label_widget::alignment`
-     * @param window The window that this widget belongs to.
      * @param parent The parent widget that owns this radio button widget.
      * @param attributes Different attributes used to configure the label widget:
      *                   a `label`, `alignment` or `text_style`
      */
-    label_widget(gui_window& window, widget *parent, label_widget_attribute auto&&...attributes) noexcept :
-        label_widget(window, parent)
+    label_widget(widget *parent, label_widget_attribute auto&&...attributes) noexcept :
+        label_widget(parent)
     {
         set_attributes(hi_forward(attributes)...);
     }
@@ -126,7 +125,7 @@ private:
         set_attributes(hi_forward(rest)...);
     }
 
-    label_widget(gui_window& window, widget *parent) noexcept;
+    label_widget(widget *parent) noexcept;
 };
 
 }} // namespace hi::v1

--- a/src/hikogui/widgets/menu_button_widget.hpp
+++ b/src/hikogui/widgets/menu_button_widget.hpp
@@ -34,7 +34,6 @@ public:
 
     /** Construct a menu button widget.
      *
-     * @param window The window that this widget belongs to.
      * @param parent The parent widget that owns this menu button widget.
      * @param delegate The delegate to use to manage the state of the menu button.
      * @param attributes Different attributes used to configure the label's on the menu button:
@@ -43,11 +42,10 @@ public:
      *                   the first label is shown in on-state and the second for off-state.
      */
     menu_button_widget(
-        gui_window& window,
         widget *parent,
         std::shared_ptr<delegate_type> delegate,
         button_widget_attribute auto&&...attributes) noexcept :
-        super(window, parent, std::move(delegate))
+        super(parent, std::move(delegate))
     {
         alignment = alignment::middle_left();
         set_attributes<0>(hi_forward(attributes)...);
@@ -55,7 +53,6 @@ public:
 
     /** Construct a menu button widget with a default button delegate.
      *
-     * @param window The window that this widget belongs to.
      * @param parent The parent widget that owns this menu button widget.
      * @param value The value or `observer` value which represents the state
      *              of the menu button.
@@ -70,13 +67,12 @@ public:
         different_from<std::shared_ptr<delegate_type>> Value,
         forward_of<observer<observer_decay_t<Value>>> OnValue,
         button_widget_attribute... Attributes>
-    menu_button_widget(gui_window& window, widget *parent, Value&& value, OnValue&& on_value, Attributes&&...attributes) noexcept
+    menu_button_widget(widget *parent, Value&& value, OnValue&& on_value, Attributes&&...attributes) noexcept
         requires requires
     {
         make_default_radio_button_delegate(hi_forward(value), hi_forward(on_value));
     } :
         menu_button_widget(
-            window,
             parent,
             make_default_radio_button_delegate(hi_forward(value), hi_forward(on_value)),
             hi_forward(attributes)...)

--- a/src/hikogui/widgets/momentary_button_widget.hpp
+++ b/src/hikogui/widgets/momentary_button_widget.hpp
@@ -21,18 +21,17 @@ public:
     using delegate_type = typename super::delegate_type;
 
     momentary_button_widget(
-        gui_window& window,
         widget *parent,
         std::shared_ptr<delegate_type> delegate,
         button_widget_attribute auto&&...attributes) noexcept :
-        super(window, parent, std::move(delegate))
+        super(parent, std::move(delegate))
     {
         alignment = alignment::middle_center();
         set_attributes<0>(hi_forward(attributes)...);
     }
 
-    momentary_button_widget(gui_window& window, widget *parent, button_widget_attribute auto&&...attributes) noexcept :
-        momentary_button_widget(window, parent, std::make_shared<delegate_type>(), hi_forward(attributes)...)
+    momentary_button_widget(widget *parent, button_widget_attribute auto&&...attributes) noexcept :
+        momentary_button_widget(parent, std::make_shared<delegate_type>(), hi_forward(attributes)...)
     {
     }
 

--- a/src/hikogui/widgets/overlay_widget.cpp
+++ b/src/hikogui/widgets/overlay_widget.cpp
@@ -7,8 +7,8 @@
 
 namespace hi::inline v1 {
 
-overlay_widget::overlay_widget(gui_window &window, widget *parent) noexcept :
-    super(window, parent)
+overlay_widget::overlay_widget(widget *parent) noexcept :
+    super(parent)
 {
     if (parent) {
         // The overlay-widget will reset the semantic_layer as it is the bottom

--- a/src/hikogui/widgets/overlay_widget.hpp
+++ b/src/hikogui/widgets/overlay_widget.hpp
@@ -43,10 +43,9 @@ public:
 
     /** Constructs an empty overlay widget.
      *
-     * @param window The window.
      * @param parent The parent widget.
      */
-    overlay_widget(gui_window& window, widget *parent) noexcept;
+    overlay_widget(widget *parent) noexcept;
 
     void set_widget(std::unique_ptr<widget> new_widget) noexcept;
 
@@ -65,7 +64,7 @@ public:
         hi_axiom(loop::main().on_thread());
         hi_assert(_content == nullptr);
 
-        auto tmp = std::make_unique<Widget>(window, this, std::forward<Args>(args)...);
+        auto tmp = std::make_unique<Widget>(this, std::forward<Args>(args)...);
         auto& ref = *tmp;
         set_widget(std::move(tmp));
         return ref;

--- a/src/hikogui/widgets/radio_button_widget.hpp
+++ b/src/hikogui/widgets/radio_button_widget.hpp
@@ -46,7 +46,6 @@ public:
 
     /** Construct a radio button widget.
      *
-     * @param window The window that this widget belongs to.
      * @param parent The parent widget that owns this radio button widget.
      * @param delegate The delegate to use to manage the state of the radio button.
      * @param attributes Different attributes used to configure the label's on the radio button:
@@ -55,11 +54,10 @@ public:
      *                   the first label is shown in on-state and the second for off-state.
      */
     radio_button_widget(
-        gui_window& window,
         widget *parent,
         std::shared_ptr<delegate_type> delegate,
         button_widget_attribute auto&&...attributes) noexcept :
-        super(window, parent, std::move(delegate))
+        super(parent, std::move(delegate))
     {
         alignment = alignment::top_left();
         set_attributes<0>(hi_forward(attributes)...);
@@ -67,7 +65,6 @@ public:
 
     /** Construct a radio button widget with a default button delegate.
      *
-     * @param window The window that this widget belongs to.
      * @param parent The parent widget that owns this radio button widget.
      * @param value The value or `observer` value which represents the state
      *              of the radio button.
@@ -82,13 +79,12 @@ public:
         different_from<std::shared_ptr<delegate_type>> Value,
         forward_of<observer<observer_decay_t<Value>>> OnValue,
         button_widget_attribute... Attributes>
-    radio_button_widget(gui_window& window, widget *parent, Value&& value, OnValue&& on_value, Attributes&&...attributes) noexcept
+    radio_button_widget(widget *parent, Value&& value, OnValue&& on_value, Attributes&&...attributes) noexcept
         requires requires
     {
         make_default_radio_button_delegate(hi_forward(value), hi_forward(on_value));
     } :
         radio_button_widget(
-            window,
             parent,
             make_default_radio_button_delegate(hi_forward(value), hi_forward(on_value)),
             hi_forward(attributes)...)

--- a/src/hikogui/widgets/row_column_widget.hpp
+++ b/src/hikogui/widgets/row_column_widget.hpp
@@ -47,10 +47,9 @@ public:
 
     /** Constructs an empty row/column widget.
      *
-     * @param window The window.
      * @param parent The parent widget.
      */
-    row_column_widget(gui_window& window, widget *parent) noexcept : super(window, parent)
+    row_column_widget(widget *parent) noexcept : super(parent)
     {
         hi_axiom(loop::main().on_thread());
 
@@ -74,7 +73,7 @@ public:
     template<typename Widget, typename... Args>
     Widget& make_widget(Args&&...args)
     {
-        auto tmp = std::make_unique<Widget>(window, this, std::forward<Args>(args)...);
+        auto tmp = std::make_unique<Widget>(this, std::forward<Args>(args)...);
         auto& ref = *tmp;
         _children.push_back(std::move(tmp));
         hi_request_reconstrain("row_column_widget::make_widget()");

--- a/src/hikogui/widgets/scroll_aperture_widget.hpp
+++ b/src/hikogui/widgets/scroll_aperture_widget.hpp
@@ -30,7 +30,7 @@ public:
     observer<float> offset_x;
     observer<float> offset_y;
 
-    scroll_aperture_widget(gui_window& window, widget *parent) noexcept : super(window, parent)
+    scroll_aperture_widget(widget *parent) noexcept : super(parent)
     {
         hi_axiom(loop::main().on_thread());
         hi_assert_not_null(parent);
@@ -54,7 +54,7 @@ public:
         hi_axiom(loop::main().on_thread());
         hi_axiom(_content == nullptr);
 
-        auto tmp = std::make_unique<Widget>(window, this, std::forward<Args>(args)...);
+        auto tmp = std::make_unique<Widget>(this, std::forward<Args>(args)...);
         auto& ref = *tmp;
         _content = std::move(tmp);
         return ref;

--- a/src/hikogui/widgets/scroll_bar_widget.hpp
+++ b/src/hikogui/widgets/scroll_bar_widget.hpp
@@ -41,12 +41,11 @@ public:
     observer<float> content;
 
     scroll_bar_widget(
-        gui_window& window,
         widget *parent,
         forward_of<observer<float>> auto&& content,
         forward_of<observer<float>> auto&& aperture,
         forward_of<observer<float>> auto&& offset) noexcept :
-        widget(window, parent), content(hi_forward(content)), aperture(hi_forward(aperture)), offset(hi_forward(offset))
+        widget(parent), content(hi_forward(content)), aperture(hi_forward(aperture)), offset(hi_forward(offset))
     {
         // clang-format off
         _content_cbt = this->content.subscribe([&](auto...){ request_relayout(); });

--- a/src/hikogui/widgets/scroll_widget.hpp
+++ b/src/hikogui/widgets/scroll_widget.hpp
@@ -56,10 +56,9 @@ public:
 
     /** Constructs an empty scroll widget.
      *
-     * @param window The window.
      * @param parent The parent widget.
      */
-    scroll_widget(gui_window& window, widget *parent) noexcept : super(window, parent)
+    scroll_widget(widget *parent) noexcept : super(parent)
     {
         hi_axiom(loop::main().on_thread());
         hi_assert_not_null(parent);
@@ -67,11 +66,11 @@ public:
         // The scroll-widget will not draw itself, only its selected content.
         semantic_layer = parent->semantic_layer;
 
-        _aperture = std::make_unique<scroll_aperture_widget>(window, this);
+        _aperture = std::make_unique<scroll_aperture_widget>(this);
         _horizontal_scroll_bar = std::make_unique<horizontal_scroll_bar_widget>(
-            window, this, _aperture->content_width, _aperture->aperture_width, _aperture->offset_x);
+            this, _aperture->content_width, _aperture->aperture_width, _aperture->offset_x);
         _vertical_scroll_bar = std::make_unique<vertical_scroll_bar_widget>(
-            window, this, _aperture->content_height, _aperture->aperture_height, _aperture->offset_y);
+            this, _aperture->content_height, _aperture->aperture_height, _aperture->offset_y);
     }
 
     /** Add a content widget directly to this scroll widget.
@@ -176,9 +175,9 @@ public:
 
             if constexpr (controls_window) {
                 if (context.left_to_right()) {
-                    window.set_resize_border_priority(true, not vertical_visible, not horizontal_visible, true);
+                    window().set_resize_border_priority(true, not vertical_visible, not horizontal_visible, true);
                 } else {
-                    window.set_resize_border_priority(not vertical_visible, true, not horizontal_visible, true);
+                    window().set_resize_border_priority(not vertical_visible, true, not horizontal_visible, true);
                 }
             }
         }

--- a/src/hikogui/widgets/selection_widget.cpp
+++ b/src/hikogui/widgets/selection_widget.cpp
@@ -16,18 +16,18 @@ selection_widget::~selection_widget()
     delegate->deinit(*this);
 }
 
-selection_widget::selection_widget(gui_window& window, widget *parent, std::shared_ptr<delegate_type> delegate) noexcept :
-    super(window, parent), delegate(std::move(delegate))
+selection_widget::selection_widget(widget *parent, std::shared_ptr<delegate_type> delegate) noexcept :
+    super(parent), delegate(std::move(delegate))
 {
     hi_assert_not_null(this->delegate);
 
     alignment = alignment::middle_left();
 
-    _current_label_widget = std::make_unique<label_widget>(window, this, alignment, text_style);
+    _current_label_widget = std::make_unique<label_widget>(this, alignment, text_style);
     _current_label_widget->mode = widget_mode::invisible;
-    _off_label_widget = std::make_unique<label_widget>(window, this, off_label, alignment, semantic_text_style::placeholder);
+    _off_label_widget = std::make_unique<label_widget>(this, off_label, alignment, semantic_text_style::placeholder);
 
-    _overlay_widget = std::make_unique<overlay_widget>(window, this);
+    _overlay_widget = std::make_unique<overlay_widget>(this);
     _overlay_widget->mode = widget_mode::invisible;
     _scroll_widget = &_overlay_widget->make_widget<vertical_scroll_widget<>>();
     _column_widget = &_scroll_widget->make_widget<column_widget>();

--- a/src/hikogui/widgets/selection_widget.hpp
+++ b/src/hikogui/widgets/selection_widget.hpp
@@ -80,15 +80,13 @@ public:
 
     /** Construct a selection widget with a delegate.
      *
-     * @param window The window the selection widget will be displayed on.
      * @param parent The owner of the selection widget.
      * @param delegate The delegate which will control the selection widget.
      */
-    selection_widget(gui_window& window, widget *parent, std::shared_ptr<delegate_type> delegate) noexcept;
+    selection_widget(widget *parent, std::shared_ptr<delegate_type> delegate) noexcept;
 
     /** Construct a selection widget with a delegate.
      *
-     * @param window The window the selection widget will be displayed on.
      * @param parent The owner of the selection widget.
      * @param delegate The delegate which will control the selection widget.
      * @param first_attribute First of @a attributes.
@@ -97,12 +95,11 @@ public:
      *                   it is used as the label to show in the off-state.
      */
     selection_widget(
-        gui_window& window,
         widget *parent,
         std::shared_ptr<delegate_type> delegate,
         selection_widget_attribute auto&& first_attribute,
         selection_widget_attribute auto&&...attributes) noexcept :
-        selection_widget(window, parent, std::move(delegate))
+        selection_widget(parent, std::move(delegate))
     {
         set_attributes(hi_forward(first_attribute), hi_forward(attributes)...);
     }
@@ -110,7 +107,6 @@ public:
     /** Construct a selection widget which will monitor an option list and a
      * value.
      *
-     * @param window The window the selection widget will be displayed on.
      * @param parent The owner of the selection widget.
      * @param value The value or observer value to monitor.
      * @param option_list An vector or an observer vector of pairs of keys and
@@ -125,7 +121,6 @@ public:
         forward_of<observer<std::vector<std::pair<observer_decay_t<Value>, label>>>> OptionList,
         selection_widget_attribute... Attributes>
     selection_widget(
-        gui_window& window,
         widget *parent,
         Value&& value,
         OptionList&& option_list,
@@ -134,7 +129,6 @@ public:
         make_default_selection_delegate(hi_forward(value), hi_forward(option_list));
     } :
         selection_widget(
-            window,
             parent,
             make_default_selection_delegate(hi_forward(value), hi_forward(option_list)),
             hi_forward(attributes)...)
@@ -144,7 +138,6 @@ public:
     /** Construct a selection widget which will monitor an option list and a
      * value.
      *
-     * @param window The window the selection widget will be displayed on.
      * @param parent The owner of the selection widget.
      * @param value The value or observer value to monitor.
      * @param option_list An vector or an observer vector of pairs of keys and
@@ -162,7 +155,6 @@ public:
         forward_of<observer<observer_decay_t<Value>>> OffValue,
         selection_widget_attribute... Attributes>
     selection_widget(
-        gui_window& window,
         widget *parent,
         Value&& value,
         OptionList&& option_list,

--- a/src/hikogui/widgets/system_menu_widget.cpp
+++ b/src/hikogui/widgets/system_menu_widget.cpp
@@ -6,9 +6,9 @@
 
 namespace hi::inline v1 {
 
-system_menu_widget::system_menu_widget(gui_window &window, widget *parent) noexcept : super(window, parent)
+system_menu_widget::system_menu_widget(widget *parent) noexcept : super(parent)
 {
-    _icon_widget = std::make_unique<icon_widget>(window, this, icon);
+    _icon_widget = std::make_unique<icon_widget>(this, icon);
 }
 
 widget_constraints const& system_menu_widget::set_constraints(set_constraints_context const& context) noexcept

--- a/src/hikogui/widgets/system_menu_widget.hpp
+++ b/src/hikogui/widgets/system_menu_widget.hpp
@@ -31,10 +31,10 @@ public:
 
     ~system_menu_widget() {}
 
-    system_menu_widget(gui_window& window, widget *parent) noexcept;
+    system_menu_widget(widget *parent) noexcept;
 
-    system_menu_widget(gui_window& window, widget *parent, forward_of<observer<hi::icon>> auto&& icon) noexcept :
-        system_menu_widget(window, parent)
+    system_menu_widget(widget *parent, forward_of<observer<hi::icon>> auto&& icon) noexcept :
+        system_menu_widget(parent)
     {
         this->icon = hi_forward(icon);
     }

--- a/src/hikogui/widgets/tab_widget.cpp
+++ b/src/hikogui/widgets/tab_widget.cpp
@@ -13,8 +13,8 @@ tab_widget::~tab_widget()
     delegate->deinit(*this);
 }
 
-tab_widget::tab_widget(gui_window& window, widget *parent, std::shared_ptr<delegate_type> delegate) noexcept :
-    super(window, parent), delegate(std::move(delegate))
+tab_widget::tab_widget(widget *parent, std::shared_ptr<delegate_type> delegate) noexcept :
+    super(parent), delegate(std::move(delegate))
 {
     hi_axiom(loop::main().on_thread());
     hi_assert_not_null(parent);

--- a/src/hikogui/widgets/tab_widget.hpp
+++ b/src/hikogui/widgets/tab_widget.hpp
@@ -44,24 +44,22 @@ public:
 
     /** Construct a tab widget with a delegate.
      *
-     * @param window The window that this widget is shown on.
      * @param parent The owner of this widget.
      * @param delegate The delegate that will control this widget.
      */
-    tab_widget(gui_window& window, widget *parent, std::shared_ptr<delegate_type> delegate) noexcept;
+    tab_widget(widget *parent, std::shared_ptr<delegate_type> delegate) noexcept;
 
     /** Construct a tab widget with an observer value.
      *
-     * @param window The window that this widget is shown on.
      * @param parent The owner of this widget.
      * @param value The value or observer value to monitor for which child widget
      *              to display.
      */
-    tab_widget(gui_window& window, widget *parent, different_from<std::shared_ptr<delegate_type>> auto&& value) noexcept requires
+    tab_widget(widget *parent, different_from<std::shared_ptr<delegate_type>> auto&& value) noexcept requires
         requires
     {
         make_default_tab_delegate(hi_forward(value));
-    } : tab_widget(window, parent, make_default_tab_delegate(hi_forward(value))) {}
+    } : tab_widget(parent, make_default_tab_delegate(hi_forward(value))) {}
 
     /** Make and add a child widget.
      *
@@ -76,7 +74,7 @@ public:
     {
         hi_axiom(loop::main().on_thread());
 
-        auto tmp = std::make_unique<WidgetType>(window, this, std::forward<Args>(args)...);
+        auto tmp = std::make_unique<WidgetType>(this, std::forward<Args>(args)...);
         auto& ref = *tmp;
 
         hi_assert_not_null(delegate);

--- a/src/hikogui/widgets/text_field_widget.cpp
+++ b/src/hikogui/widgets/text_field_widget.cpp
@@ -7,8 +7,8 @@
 
 namespace hi::inline v1 {
 
-text_field_widget::text_field_widget(gui_window& window, widget *parent, std::shared_ptr<delegate_type> delegate) noexcept :
-    super(window, parent), delegate(std::move(delegate)), _text()
+text_field_widget::text_field_widget(widget *parent, std::shared_ptr<delegate_type> delegate) noexcept :
+    super(parent), delegate(std::move(delegate)), _text()
 {
     hi_assert_not_null(this->delegate);
     _delegate_cbt = this->delegate->subscribe([&] {
@@ -16,12 +16,12 @@ text_field_widget::text_field_widget(gui_window& window, widget *parent, std::sh
     });
     this->delegate->init(*this);
 
-    _scroll_widget = std::make_unique<scroll_widget<axis::none, false>>(window, this);
+    _scroll_widget = std::make_unique<scroll_widget<axis::none, false>>(this);
     _text_widget = &_scroll_widget->make_widget<text_widget>(_text, alignment, text_style);
     _text_widget->mode = widget_mode::partial;
 
     _error_label_widget =
-        std::make_unique<label_widget>(window, this, _error_label, alignment::top_left(), semantic_text_style::error);
+        std::make_unique<label_widget>(this, _error_label, alignment::top_left(), semantic_text_style::error);
 
     _continues_cbt = continues.subscribe([&](auto...) {
         hi_request_reconstrain("text_field_widget::_continues_cbt()");

--- a/src/hikogui/widgets/text_field_widget.hpp
+++ b/src/hikogui/widgets/text_field_widget.hpp
@@ -81,33 +81,30 @@ public:
 
     virtual ~text_field_widget();
 
-    text_field_widget(gui_window& window, widget *parent, std::shared_ptr<delegate_type> delegate) noexcept;
+    text_field_widget(widget *parent, std::shared_ptr<delegate_type> delegate) noexcept;
 
     text_field_widget(
-        gui_window& window,
         widget *parent,
         std::shared_ptr<delegate_type> delegate,
         text_field_widget_attribute auto&&...attributes) noexcept :
-        text_field_widget(window, parent, std::move(delegate))
+        text_field_widget(parent, std::move(delegate))
     {
         set_attributes(hi_forward(attributes)...);
     }
 
     /** Construct a text field widget.
      *
-     * @param window The window the widget is displayed on.
      * @param parent The owner of this widget.
      * @param value The value or `observer` value which represents the state of the text-field.
      * @param attributes A set of attributes used to configure the text widget: a `alignment` or `semantic_text_style`.
      */
     text_field_widget(
-        gui_window& window,
         widget *parent,
         different_from<std::shared_ptr<delegate_type>> auto&& value,
         text_field_widget_attribute auto&&...attributes) noexcept requires requires
     {
         make_default_text_field_delegate(hi_forward(value));
-    } : text_field_widget(window, parent, make_default_text_field_delegate(hi_forward(value)), hi_forward(attributes)...) {}
+    } : text_field_widget(parent, make_default_text_field_delegate(hi_forward(value)), hi_forward(attributes)...) {}
 
     /// @privatesection
     [[nodiscard]] generator<widget *> children() const noexcept override;

--- a/src/hikogui/widgets/text_widget.cpp
+++ b/src/hikogui/widgets/text_widget.cpp
@@ -10,8 +10,8 @@
 
 namespace hi::inline v1 {
 
-text_widget::text_widget(gui_window& window, widget *parent, std::shared_ptr<delegate_type> delegate) noexcept :
-    super(window, parent), delegate(std::move(delegate))
+text_widget::text_widget(widget *parent, std::shared_ptr<delegate_type> delegate) noexcept :
+    super(parent), delegate(std::move(delegate))
 {
     mode = widget_mode::select;
 
@@ -79,7 +79,7 @@ widget_constraints const& text_widget::set_constraints(set_constraints_context c
 void text_widget::set_layout(widget_layout const& context) noexcept
 {
     if (compare_store(_layout, context)) {
-        auto alignment_ = context.left_to_right() ? *alignment : mirror(*alignment); 
+        auto alignment_ = context.left_to_right() ? *alignment : mirror(*alignment);
 
         _shaped_text.layout(context.rectangle(), context.baseline, context.sub_pixel_size, context.writing_direction, alignment_);
 

--- a/src/hikogui/widgets/text_widget.hpp
+++ b/src/hikogui/widgets/text_widget.hpp
@@ -77,37 +77,33 @@ public:
 
     /** Construct a text widget.
      *
-     * @param window The window the widget is displayed on.
      * @param parent The owner of this widget.
      * @param delegate The delegate to use to control the widget's data.
      */
-    text_widget(gui_window& window, widget *parent, std::shared_ptr<delegate_type> delegate) noexcept;
+    text_widget(widget *parent, std::shared_ptr<delegate_type> delegate) noexcept;
 
     text_widget(
-        gui_window& window,
         widget *parent,
         std::shared_ptr<delegate_type> delegate,
         text_widget_attribute auto&&...attributes) noexcept :
-        text_widget(window, parent, std::move(delegate))
+        text_widget(parent, std::move(delegate))
     {
         set_attributes(hi_forward(attributes)...);
     }
 
     /** Construct a text widget.
      *
-     * @param window The window the widget is displayed on.
      * @param parent The owner of this widget.
      * @param text The text to be displayed.
      * @param attributes A set of attributes used to configure the text widget: a `alignment` or `semantic_text_style`.
      */
     text_widget(
-        gui_window& window,
         widget *parent,
         different_from<std::shared_ptr<delegate_type>> auto&& text,
         text_widget_attribute auto&&...attributes) noexcept requires requires
     {
         make_default_text_delegate(hi_forward(text));
-    } : text_widget(window, parent, make_default_text_delegate(hi_forward(text)), hi_forward(attributes)...) {}
+    } : text_widget(parent, make_default_text_delegate(hi_forward(text)), hi_forward(attributes)...) {}
 
     /// @privatesection
     widget_constraints const& set_constraints(set_constraints_context const &context) noexcept override;

--- a/src/hikogui/widgets/toggle_widget.hpp
+++ b/src/hikogui/widgets/toggle_widget.hpp
@@ -56,7 +56,6 @@ public:
 
     /** Construct a toggle widget.
      *
-     * @param window The window that this widget belongs to.
      * @param parent The parent widget that owns this toggle widget.
      * @param delegate The delegate to use to manage the state of the toggle button.
      * @param attributes Different attributes used to configure the label's on the toggle button:
@@ -65,11 +64,10 @@ public:
      *                   the labels are shown in on-state, off-state and other-state in that order.
      */
     toggle_widget(
-        gui_window& window,
         widget *parent,
         std::shared_ptr<delegate_type> delegate,
         button_widget_attribute auto&&...attributes) noexcept :
-        super(window, parent, std::move(delegate))
+        super(parent, std::move(delegate))
     {
         alignment = alignment::top_left();
         set_attributes<0>(hi_forward(attributes)...);
@@ -78,7 +76,6 @@ public:
     /** Construct a toggle widget with a default button delegate.
      *
      * @see default_button_delegate
-     * @param window The window that this widget belongs to.
      * @param parent The parent widget that owns this toggle widget.
      * @param value The value or `observer` value which represents the state of the toggle.
      * @param attributes Different attributes used to configure the label's on the toggle button:
@@ -87,15 +84,14 @@ public:
      *                   the labels are shown in on-state, off-state and other-state in that order.
      */
     template<different_from<std::shared_ptr<delegate_type>> Value, button_widget_attribute... Attributes>
-    toggle_widget(gui_window& window, widget *parent, Value&& value, Attributes&&...attributes) noexcept requires requires
+    toggle_widget(widget *parent, Value&& value, Attributes&&...attributes) noexcept requires requires
     {
         make_default_toggle_button_delegate(hi_forward(value));
-    } : toggle_widget(window, parent, make_default_toggle_button_delegate(hi_forward(value)), hi_forward(attributes)...) {}
+    } : toggle_widget(parent, make_default_toggle_button_delegate(hi_forward(value)), hi_forward(attributes)...) {}
 
     /** Construct a toggle widget with a default button delegate.
      *
      * @see default_button_delegate
-     * @param window The window that this widget belongs to.
      * @param parent The parent widget that owns this toggle widget.
      * @param value The value or `observer` value which represents the state of the toggle.
      * @param on_value The on-value. This value is used to determine which value yields an 'on' state.
@@ -108,7 +104,7 @@ public:
         different_from<std::shared_ptr<delegate_type>> Value,
         forward_of<observer<observer_decay_t<Value>>> OnValue,
         button_widget_attribute... Attributes>
-    toggle_widget(gui_window& window, widget *parent, Value&& value, OnValue&& on_value, Attributes&&...attributes) noexcept
+    toggle_widget(widget *parent, Value&& value, OnValue&& on_value, Attributes&&...attributes) noexcept
         requires requires
     {
         make_default_toggle_button_delegate(hi_forward(value), hi_forward(on_value));
@@ -124,7 +120,6 @@ public:
     /** Construct a toggle widget with a default button delegate.
      *
      * @see default_button_delegate
-     * @param window The window that this widget belongs to.
      * @param parent The parent widget that owns this toggle widget.
      * @param value The value or `observer` value which represents the state of the toggle.
      * @param on_value The on-value. This value is used to determine which value yields an 'on' state.
@@ -140,7 +135,6 @@ public:
         forward_of<observer<observer_decay_t<Value>>> OffValue,
         button_widget_attribute... Attributes>
     toggle_widget(
-        gui_window& window,
         widget *parent,
         Value&& value,
         OnValue&& on_value,
@@ -150,7 +144,6 @@ public:
         make_default_toggle_button_delegate(hi_forward(value), hi_forward(on_value), hi_forward(off_value));
     } :
         toggle_widget(
-            window,
             parent,
             make_default_toggle_button_delegate(hi_forward(value), hi_forward(on_value), hi_forward(off_value)),
             hi_forward(attributes)...)

--- a/src/hikogui/widgets/toolbar_button_widget.hpp
+++ b/src/hikogui/widgets/toolbar_button_widget.hpp
@@ -22,18 +22,17 @@ public:
     using delegate_type = typename super::delegate_type;
 
     toolbar_button_widget(
-        gui_window& window,
         widget *parent,
         std::shared_ptr<delegate_type> delegate,
         button_widget_attribute auto&&...attributes) noexcept :
-        super(window, parent, std::move(delegate))
+        super(parent, std::move(delegate))
     {
         alignment = alignment::middle_left();
         set_attributes<0>(hi_forward(attributes)...);
     }
 
-    toolbar_button_widget(gui_window& window, widget *parent, button_widget_attribute auto&&...attributes) noexcept :
-        toolbar_button_widget(window, parent, std::make_shared<button_delegate>(), hi_forward(attributes)...)
+    toolbar_button_widget(widget *parent, button_widget_attribute auto&&...attributes) noexcept :
+        toolbar_button_widget(parent, std::make_shared<button_delegate>(), hi_forward(attributes)...)
     {
     }
 

--- a/src/hikogui/widgets/toolbar_tab_button_widget.hpp
+++ b/src/hikogui/widgets/toolbar_tab_button_widget.hpp
@@ -50,7 +50,6 @@ public:
 
     /** Construct a toolbar tab button widget.
      *
-     * @param window The window that this widget belongs to.
      * @param parent The parent widget that owns this radio button widget.
      * @param delegate The delegate to use to manage the state of the tab button widget.
      * @param attributes Different attributes used to configure the label's on the toolbar tab button:
@@ -59,11 +58,10 @@ public:
      *                   the first label is shown in on-state and the second for off-state.
      */
     toolbar_tab_button_widget(
-        gui_window& window,
         widget *parent,
         std::shared_ptr<delegate_type> delegate,
         button_widget_attribute auto&&...attributes) noexcept :
-        super(window, parent, std::move(delegate))
+        super(parent, std::move(delegate))
     {
         alignment = alignment::top_center();
         set_attributes<0>(hi_forward(attributes)...);
@@ -71,7 +69,6 @@ public:
 
     /** Construct a toolbar tab button widget with a default button delegate.
      *
-     * @param window The window that this widget belongs to.
      * @param parent The parent widget that owns this toolbar tab button widget.
      * @param value The value or `observer` value which represents the state
      *              of the toolbar tab button.
@@ -87,7 +84,6 @@ public:
         forward_of<observer<observer_decay_t<Value>>> OnValue,
         button_widget_attribute... Attributes>
     toolbar_tab_button_widget(
-        gui_window& window,
         widget *parent,
         Value&& value,
         OnValue&& on_value,
@@ -96,7 +92,6 @@ public:
         make_default_radio_button_delegate(hi_forward(value), hi_forward(on_value));
     } :
         toolbar_tab_button_widget(
-            window,
             parent,
             make_default_radio_button_delegate(hi_forward(value), hi_forward(on_value)),
             hi_forward(attributes)...)

--- a/src/hikogui/widgets/toolbar_widget.cpp
+++ b/src/hikogui/widgets/toolbar_widget.cpp
@@ -9,7 +9,7 @@
 
 namespace hi::inline v1 {
 
-toolbar_widget::toolbar_widget(gui_window& window, widget *parent) noexcept : super(window, parent)
+toolbar_widget::toolbar_widget(widget *parent) noexcept : super(parent)
 {
     hi_axiom(loop::main().on_thread());
 

--- a/src/hikogui/widgets/toolbar_widget.hpp
+++ b/src/hikogui/widgets/toolbar_widget.hpp
@@ -37,10 +37,9 @@ public:
 
     /** Constructs an empty row/column widget.
      *
-     * @param window The window.
      * @param parent The parent widget.
      */
-    toolbar_widget(gui_window& window, widget *parent) noexcept;
+    toolbar_widget(widget *parent) noexcept;
 
     /** Add a widget directly to this toolbar-widget.
      *
@@ -60,7 +59,7 @@ public:
     template<typename Widget, horizontal_alignment Alignment = horizontal_alignment::left, typename... Args>
     Widget& make_widget(Args&&...args)
     {
-        auto widget = std::make_unique<Widget>(window, this, std::forward<Args>(args)...);
+        auto widget = std::make_unique<Widget>(this, std::forward<Args>(args)...);
         return static_cast<Widget&>(add_widget(Alignment, std::move(widget)));
     }
 

--- a/src/hikogui/widgets/widget.cpp
+++ b/src/hikogui/widgets/widget.cpp
@@ -10,8 +10,8 @@
 
 namespace hi::inline v1 {
 
-widget::widget(gui_window& _window, widget *parent) noexcept :
-    window(_window), parent(parent), logical_layer(0), semantic_layer(0)
+widget::widget(widget *parent) noexcept :
+    parent(parent), logical_layer(0), semantic_layer(0)
 {
     hi_axiom(loop::main().on_thread());
 
@@ -33,7 +33,17 @@ widget::~widget()
 {
     // The window must remove references such as mouse and keyboard targets to
     // this widget when it is removed.
-    window.widget_is_destructing(this);
+    _window->widget_is_destructing(this);
+}
+
+void widget::set_window(gui_window *window)
+{
+    _window = window;
+}
+
+[[nodiscard]] gui_window& widget::window() noexcept
+{
+    return *_window;
 }
 
 [[nodiscard]] color widget::background_color() const noexcept

--- a/src/hikogui/widgets/widget.hpp
+++ b/src/hikogui/widgets/widget.hpp
@@ -44,9 +44,9 @@ class font_book;
  */
 class widget {
 public:
-    /** Convenient reference to the Window.
+    /** Pointer to the Window.
      */
-    gui_window& window;
+    gui_window *_window;
 
     /** Pointer to the parent widget.
      * May be a nullptr only when this is the top level widget.
@@ -97,13 +97,16 @@ public:
 
     /*! Constructor for creating sub views.
      */
-    widget(gui_window& window, widget *parent) noexcept;
+    widget(widget *parent) noexcept;
 
     virtual ~widget();
     widget(const widget&) = delete;
     widget& operator=(const widget&) = delete;
     widget(widget&&) = delete;
     widget& operator=(widget&&) = delete;
+
+    void set_window(gui_window *window);
+    virtual gui_window& window() noexcept;
 
     /** Find the widget that is under the mouse cursor.
      * This function will recursively test with visual child widgets, when

--- a/src/hikogui/widgets/window_traffic_lights_widget.cpp
+++ b/src/hikogui/widgets/window_traffic_lights_widget.cpp
@@ -11,7 +11,7 @@
 
 namespace hi::inline v1 {
 
-window_traffic_lights_widget::window_traffic_lights_widget(gui_window& window, widget *parent) noexcept : super(window, parent) {}
+window_traffic_lights_widget::window_traffic_lights_widget(widget *parent) noexcept : super(parent) {}
 
 widget_constraints const& window_traffic_lights_widget::set_constraints(set_constraints_context const &context) noexcept
 {
@@ -226,18 +226,18 @@ bool window_traffic_lights_widget::handle_event(gui_event const& event) noexcept
             request_redraw();
 
             if (closeRectangle.contains(event.mouse().position)) {
-                window.close_window();
+                window().close_window();
 
             } else if (minimizeRectangle.contains(event.mouse().position)) {
-                window.set_size_state(gui_window_size::minimized);
+                window().set_size_state(gui_window_size::minimized);
 
             } else if (maximizeRectangle.contains(event.mouse().position)) {
                 switch (layout().window_size_state) {
                 case gui_window_size::normal:
-                    window.set_size_state(gui_window_size::maximized);
+                    window().set_size_state(gui_window_size::maximized);
                     break;
                 case gui_window_size::maximized:
-                    window.set_size_state(gui_window_size::normal);
+                    window().set_size_state(gui_window_size::normal);
                     break;
                 default:
                     hi_no_default();

--- a/src/hikogui/widgets/window_traffic_lights_widget.hpp
+++ b/src/hikogui/widgets/window_traffic_lights_widget.hpp
@@ -27,7 +27,7 @@ class window_traffic_lights_widget final : public widget {
 public:
     using super = widget;
 
-    window_traffic_lights_widget(gui_window& window, widget *parent) noexcept;
+    window_traffic_lights_widget(widget *parent) noexcept;
 
     /// @privatesection
     widget_constraints const& set_constraints(set_constraints_context const &context) noexcept override;

--- a/src/hikogui/widgets/window_widget.cpp
+++ b/src/hikogui/widgets/window_widget.cpp
@@ -17,7 +17,7 @@ namespace hi::inline v1 {
 
 void window_widget::constructor_implementation() noexcept
 {
-    _toolbar = std::make_unique<toolbar_widget>(window, this);
+    _toolbar = std::make_unique<toolbar_widget>(this);
 
     if (operating_system::current == operating_system::windows) {
 #if HI_OPERATING_SYSTEM == HI_OS_WINDOWS
@@ -31,7 +31,7 @@ void window_widget::constructor_implementation() noexcept
         hi_no_default();
     }
 
-    _content = std::make_unique<grid_widget>(window, this);
+    _content = std::make_unique<grid_widget>(this);
 }
 
 [[nodiscard]] generator<widget *> window_widget::children() const noexcept
@@ -221,6 +221,11 @@ void window_widget::set_resize_border_priority(bool left, bool right, bool botto
     return *_toolbar;
 }
 
+[[nodiscard]] gui_window& window_widget::window() noexcept
+{
+    return *_window;
+}
+
 bool window_widget::handle_event(gui_event const& event) noexcept
 {
     switch (event.type()) {
@@ -230,7 +235,7 @@ bool window_widget::handle_event(gui_event const& event) noexcept
 
     case gui_event_type::gui_sysmenu_open:
         if (*mode >= widget_mode::partial) {
-            window.open_system_menu();
+            _window->open_system_menu();
             return true;
         }
         break;
@@ -240,29 +245,29 @@ bool window_widget::handle_event(gui_event const& event) noexcept
 
 [[nodiscard]] std::string window_widget::get_text_from_clipboard() const noexcept
 {
-    return window.get_text_from_clipboard();
+    return _window->get_text_from_clipboard();
 }
 
 void window_widget::set_text_on_clipboard(std::string_view text) const noexcept
 {
-    window.set_text_on_clipboard(text);
+     _window->set_text_on_clipboard(text);
 }
 
 bool window_widget::process_event(gui_event const& event) noexcept
 {
-    return window.process_event(event);
+    return window().process_event(event);
 }
 
 void window_widget::update_keyboard_target(widget const *widget, keyboard_focus_group group) noexcept
 {
-    window.update_keyboard_target(widget, group);
+    window().update_keyboard_target(widget, group);
 }
 
 void window_widget::update_keyboard_target(
     keyboard_focus_group group,
     keyboard_focus_direction direction) noexcept
 {
-    window.update_keyboard_target(group, direction);
+    window().update_keyboard_target(group, direction);
 }
 
 void window_widget::update_keyboard_target(
@@ -270,27 +275,27 @@ void window_widget::update_keyboard_target(
     keyboard_focus_group group,
     keyboard_focus_direction direction) noexcept
 {
-    window.update_keyboard_target(widget, group, direction);
+    window().update_keyboard_target(widget, group, direction);
 }
 
 void window_widget::_request_redraw(aarectangle dirty_rectangle) const noexcept
 {
-    window.request_redraw(dirty_rectangle);
+    _window->request_redraw(dirty_rectangle);
 }
 
 void window_widget::_request_relayout() const noexcept
 {
-    window.request_relayout(this);
+    _window->request_relayout(this);
 }
 
 void window_widget::_request_reconstrain() const noexcept
 {
-    window.request_reconstrain(this);
+    _window->request_reconstrain(this);
 }
 
 void window_widget::_request_resize() const noexcept
 {
-    window.request_resize(this);
+    _window->request_resize(this);
 }
 
 } // namespace hi::inline v1

--- a/src/hikogui/widgets/window_widget.hpp
+++ b/src/hikogui/widgets/window_widget.hpp
@@ -28,9 +28,10 @@ public:
 
     observer<label> title;
 
-    window_widget(gui_window& window, forward_of<observer<label>> auto&& title) noexcept :
-        super(window, nullptr), title(hi_forward(title))
+    window_widget(gui_window *window, forward_of<observer<label>> auto&& title) noexcept :
+        super(nullptr), title(hi_forward(title))
     {
+        this->_window = window;
         constructor_implementation();
     }
 
@@ -58,6 +59,7 @@ public:
 
     /// @privatesection
     [[nodiscard]] generator<widget *> children() const noexcept override;
+    [[nodiscard]] gui_window& window() noexcept override;
     widget_constraints const& set_constraints(set_constraints_context const& context) noexcept override;
     void set_layout(widget_layout const& context) noexcept;
     void draw(draw_context const& context) noexcept override;


### PR DESCRIPTION
- disabled adding CTest build 
- removes the window argument from widget constructors 
- gui_window::init() passes gui_window as pointer "_window" into "window_widget" 
- add set_window(), window() to widget removed 
- fixed some window accesses