### PR TITLE
update cleanup-workflows to "actions/github-script@v6"

### DIFF
--- a/.github/workflows/cleanup-workflows.yml
+++ b/.github/workflows/cleanup-workflows.yml
@@ -3,7 +3,6 @@
 #
 # Copyright 2021 Ching Chow, Jens A. Koch.
 #
-# Taken from: https://github.community/t/delete-old-workflow-results/
 # This file is part of https://github.com/hikogui/hikogui
 
 name: Clean Workflow Runs
@@ -29,28 +28,26 @@ jobs:
 
     steps:
       - name: ✂ Remove cancelled or skipped workflow runs
-        uses: actions/github-script@v4 # https://github.com/actions/github-script
+        uses: actions/github-script@v6 # https://github.com/actions/github-script
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const cancelled = await github.actions.listWorkflowRunsForRepo({
+            const cancelled = await github.rest.actions.listWorkflowRunsForRepo({
               owner: context.repo.owner,
-              per_page: 100,
               repo: context.repo.repo,
-              status: 'cancelled',
+              per_page: 100,
+              status: 'cancelled'
             });
-
-            const skipped = await github.actions.listWorkflowRunsForRepo({
+            const skipped = await github.rest.actions.listWorkflowRunsForRepo({
               owner: context.repo.owner,
-              per_page: 100,
               repo: context.repo.repo,
-              status: 'skipped',
+              per_page: 100,
+              status: 'skipped'
             });
-
             for (const response of [cancelled, skipped]) {
               for (const run of response.data.workflow_runs) {
                 console.log(`[Deleting] Run id ${run.id} of '${run.name}' is a cancelled or skipped run.`);
-                await github.actions.deleteWorkflowRun({
+                await github.rest.actions.deleteWorkflowRun({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
                   run_id: run.id
@@ -58,35 +55,30 @@ jobs:
               }
             }
 
-      - name: ✂ Remove 30 days old workflows runs
-        uses: actions/github-script@v4 # https://github.com/actions/github-script
+      - name: ✂ Remove 14 days old workflows runs
+        uses: actions/github-script@v6 # https://github.com/actions/github-script
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const days_to_expiration = 30;
+            const days_to_expiration = 14;
             const ms_in_day = 86400000;
             const now = Date.now();
             const pages = 5;
-
             // list the workflows runs to remove here
-
             const workflows = [
               'build-on-windows.yml',
               'publish-PR-test-results.yml'
             ]
-
             let runs_to_delete = [];
-
             for (const workflow of workflows) {
               for (let page = 0; page < pages; page += 1) {
-                let response = await github.actions.listWorkflowRuns({
+                const response = await github.rest.actions.listWorkflowRuns({
                   owner: context.repo.owner,
-                  page: page,
-                  per_page: 100,
                   repo: context.repo.repo,
-                  workflow_id: workflow
+                  workflow_id: workflow,
+                  page: page,
+                  per_page: 100
                 });
-
                 if (response.data.workflow_runs.length > 0) {
                   for (const run of response.data.workflow_runs) {
                     if (now - Date.parse(run.created_at) > ms_in_day * days_to_expiration) {
@@ -96,11 +88,10 @@ jobs:
                 }
               }
             }
-
             for (const run of runs_to_delete) {
               console.log(`[Deleting] Run id ${run[0]} of '${run[1]}' is older than ${days_to_expiration} days.`);
               try {
-                await github.actions.deleteWorkflowRun({
+                await github.rest.actions.deleteWorkflowRun({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
                   run_id: run[0]
@@ -111,34 +102,30 @@ jobs:
             }
 
       - name: ✂ Remove runs of the cleanup workflow itself
-        uses: actions/github-script@v4 # https://github.com/actions/github-script
+        uses: actions/github-script@v6 # https://github.com/actions/github-script
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const pages = 5;
-
             let runs_to_delete = [];
-
             for (let page = 0; page < pages; page += 1) {
-              let response = await github.actions.listWorkflowRuns({
+              const response = await github.rest.actions.listWorkflowRuns({
                 owner: context.repo.owner,
                 page: page,
                 per_page: 100,
                 repo: context.repo.repo,
-                workflow_id: 'cleanup-workflows.yml'
+                workflow_id: 'cleanup-workflows.yml',
               });
-
               if (response.data.workflow_runs.length > 0) {
                 for (const run of response.data.workflow_runs) {
-                    runs_to_delete.push([run.id, run.name]);
+                  runs_to_delete.push([run.id, run.name]);
                 }
               }
             }
-
             for (const run of runs_to_delete) {
               console.log(`[Deleting] Run id ${run[0]} of '${run[1]}'.`);
               try {
-                await github.actions.deleteWorkflowRun({
+                await github.rest.actions.deleteWorkflowRun({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
                   run_id: run[0]


### PR DESCRIPTION
This fixes the "Node.js 12 actions are deprecated" and "set-output" warnings.