### PR TITLE
Hebrew character at end of text displayed with replacement-character.

### DIFF
--- a/examples/hikogui_demo/src/main.cpp
+++ b/examples/hikogui_demo/src/main.cpp
@@ -80,7 +80,7 @@ hi::scoped_task<> init_audio_tab(hi::grid_widget& grid, my_preferences& preferen
     co_await std::suspend_always{};
 }
 
-hi::scoped_task<> init_theme_tab(hi::grid_widget& grid, my_preferences& preferences, hi::theme_book &theme_book) noexcept
+hi::scoped_task<> init_theme_tab(hi::grid_widget& grid, my_preferences& preferences, hi::theme_book& theme_book) noexcept
 {
     using namespace hi;
 
@@ -123,7 +123,8 @@ hi::scoped_task<> init_license_tab(hi::grid_widget& grid, my_preferences& prefer
         std::pair{3, label{tr("four")}},
         std::pair{4, label{tr("five")}},
         std::pair{5, label{tr("six")}},
-        std::pair{6, label{"\xd7\xa9\xd7\x91\xd7\xa2\xd7\x94 "}}};
+        std::pair{6, label{tr("seven")}}};
+
     grid.make_widget<label_widget>("A6", tr("This is a selection box at the bottom:"));
     auto& selection3 = grid.make_widget<selection_widget>("B6", preferences.radio_value, option_list);
 

--- a/src/hikogui/char_maps/CMakeLists.txt
+++ b/src/hikogui/char_maps/CMakeLists.txt
@@ -17,6 +17,7 @@ target_sources(hikogui PRIVATE
 if(BUILD_TESTING)
     target_sources(hikogui_tests PRIVATE
         ascii_tests.cpp
+        char_converter_tests.cpp
         cp_1252_tests.cpp
         iso_8859_1_tests.cpp
         utf_8_tests.cpp

--- a/src/hikogui/char_maps/char_converter_tests.cpp
+++ b/src/hikogui/char_maps/char_converter_tests.cpp
@@ -1,0 +1,23 @@
+﻿// Copyright Take Vos 2022.
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at https://www.boost.org/LICENSE_1_0.txt)
+
+#include "utf_8.hpp"
+#include "utf_32.hpp"
+#include <gtest/gtest.h>
+#include <iostream>
+#include <format>
+
+using namespace std;
+using namespace hi;
+
+TEST(char_converter, utf8_to_utf32_large_char_at_end)
+{
+    // "seven" in Hebrew.
+    auto test = std::string{"\xd7\xa9\xd7\x91\xd7\xa2\xd7\x94"};
+    auto expected = std::u32string{U"\u05E9\u05D1\u05E2\u05d4"};
+
+    auto result = char_converter<"utf-8", "utf-32">{}.convert<std::u32string>(test);
+
+    ASSERT_EQ(result, expected);
+}

--- a/src/hikogui/char_maps/utf_8.hpp
+++ b/src/hikogui/char_maps/utf_8.hpp
@@ -52,8 +52,7 @@ struct char_map<"utf-8"> {
             return read_fallback(it, last);
 
         } else {
-            auto length = narrow_cast<uint8_t>(std::countl_one(char_cast<uint8_t>(cu)));
-            auto todo = length - 2;
+            hilet length = narrow_cast<uint8_t>(std::countl_one(char_cast<uint8_t>(cu)));
             hi_axiom(length >= 2);
 
             // First part of the code-point.
@@ -69,7 +68,11 @@ struct char_map<"utf-8"> {
                 it -= 2;
                 return read_fallback(it, last);
 
-            } else if (todo >= std::distance(it, last)) [[unlikely]] {
+            }
+            
+            // After we read the first two code-units how many more to do.
+            auto todo = length - 2;
+            if (todo > std::distance(it, last)) [[unlikely]] {
                 // If there is a start and a continuation code-unit in a row we consider this to be UTF-8 encoded.
                 // So at this point any errors are replaced with 0xfffd.
                 it = last;

--- a/src/hikogui/widgets/text_delegate.hpp
+++ b/src/hikogui/widgets/text_delegate.hpp
@@ -66,6 +66,42 @@ class default_text_delegate;
  * @ingroup widget_delegates
  */
 template<>
+class default_text_delegate<char const *> : public text_delegate {
+public:
+    using value_type = char const *;
+
+    observer<value_type> value;
+
+    /** Construct a delegate.
+     *
+     * @param value A value or observer-value used as a representation of the state.
+     */
+    explicit default_text_delegate(forward_of<observer<value_type>> auto&& value) noexcept : value(hi_forward(value))
+    {
+        _value_cbt = this->value.subscribe([&](auto...) {
+            this->_notifier();
+        });
+    }
+
+    [[nodiscard]] gstring read(text_widget& sender) noexcept override
+    {
+        return to_gstring(std::string{*value});
+    }
+
+    void write(text_widget& sender, gstring const& text) noexcept override
+    {
+        hi_no_default();
+    }
+
+private:
+    typename decltype(value)::callback_token _value_cbt;
+};
+
+/** A default text delegate specialization for `std::string`.
+ *
+ * @ingroup widget_delegates
+ */
+template<>
 class default_text_delegate<std::string> : public text_delegate {
 public:
     using value_type = std::string;


### PR DESCRIPTION
Fix #454: Off by one in utf-8 decoder.