### PR TITLE
Fixed: selection box drawing in right-to-left mode.

### DIFF
--- a/src/hikogui/GFX/draw_context.hpp
+++ b/src/hikogui/GFX/draw_context.hpp
@@ -16,6 +16,7 @@
 #include "../geometry/transform.hpp"
 #include "../geometry/circle.hpp"
 #include "../geometry/line_end_cap.hpp"
+#include "../unicode/unicode_bidi_class.hpp"
 #include "../text/text_cursor.hpp"
 #include "../text/text_selection.hpp"
 #include "../text/text_shaper.hpp"
@@ -69,6 +70,12 @@ public:
      */
     hi::subpixel_orientation subpixel_orientation;
 
+    /** The default writing direction.
+     *
+     * @note Must be either `L` or `R`.
+     */
+    unicode_bidi_class writing_direction = unicode_bidi_class::L;
+
     /** Window is active.
      */
     bool active;
@@ -99,6 +106,11 @@ public:
     operator bool() const noexcept
     {
         return frame_buffer_index != std::numeric_limits<size_t>::max();
+    }
+
+    [[nodiscard]] constexpr bool left_to_right() const noexcept
+    {
+        return writing_direction == unicode_bidi_class::L;
     }
 
     /** Draw a box with rounded corners.

--- a/src/hikogui/GUI/gui_window.cpp
+++ b/src/hikogui/GUI/gui_window.cpp
@@ -159,8 +159,8 @@ void gui_window::render(utc_nanoseconds display_time_point)
             _size_state,
             *gui.font_book,
             theme,
-            this->subpixel_orientation(),
-            this->writing_direction(),
+            subpixel_orientation(),
+            writing_direction(),
             display_time_point});
 
         // After layout do a complete redraw.
@@ -177,6 +177,7 @@ void gui_window::render(utc_nanoseconds display_time_point)
         _redraw_rectangle = aarectangle{};
         draw_context.display_time_point = display_time_point;
         draw_context.subpixel_orientation = subpixel_orientation();
+        draw_context.writing_direction = writing_direction();
         draw_context.background_color = widget->background_color();
         draw_context.active = active;
 

--- a/src/hikogui/widgets/selection_widget.cpp
+++ b/src/hikogui/widgets/selection_widget.cpp
@@ -333,7 +333,9 @@ void selection_widget::draw_outline(draw_context const& context) noexcept
 
 void selection_widget::draw_left_box(draw_context const& context) noexcept
 {
-    hilet corner_radii = hi::corner_radii{layout().theme->rounding_radius, 0.0f, layout().theme->rounding_radius, 0.0f};
+    hilet corner_radii = context.left_to_right() ?
+        hi::corner_radii{layout().theme->rounding_radius, 0.0f, layout().theme->rounding_radius, 0.0f} :
+        hi::corner_radii{0.0f, layout().theme->rounding_radius, 0.0f, layout().theme->rounding_radius};
     context.draw_box(layout(), translate_z(0.1f) * _left_box_rectangle, focus_color(), corner_radii);
 }
 


### PR DESCRIPTION
Fix #456: Added left_to_right() to the draw_context and fix the selection box.