### PR TITLE
updating actions/cache to latest version 3.2.3

### DIFF
--- a/.github/workflows/build-on-windows.yml
+++ b/.github/workflows/build-on-windows.yml
@@ -71,7 +71,7 @@ jobs:
 
       - name: 🎯 Cache VULKAN SDK & Runtime
         id: cache-vulkan
-        uses: actions/cache@v3.2.3
+        uses: actions/cache@v3
         with:
           path: ${{steps.vulkan-version.outputs.VULKAN_SDK}}
           key: cache-windows-vulkan-${{steps.vulkan-version.outputs.VULKAN_VERSION}}-0

--- a/.github/workflows/build-on-windows.yml
+++ b/.github/workflows/build-on-windows.yml
@@ -71,7 +71,7 @@ jobs:
 
       - name: 🎯 Cache VULKAN SDK & Runtime
         id: cache-vulkan
-        uses: actions/cache@v3.0.11
+        uses: actions/cache@v3.2.3
         with:
           path: ${{steps.vulkan-version.outputs.VULKAN_SDK}}
           key: cache-windows-vulkan-${{steps.vulkan-version.outputs.VULKAN_VERSION}}-0


### PR DESCRIPTION
let's see if this resolves the folder creation issues.
first commit upgrades to `v3.2.3` and primes the cache.
second commit reduced to `v3` and uses the cache.

referencing upstream issue: https://github.com/actions/cache/issues/972

because the tar extraction of the cached file worked with the newer version in my fork,
i closed the upstream issue as resolved.