### PR TITLE
fix downloading of "test-results" artifact in PRs

### DIFF
--- a/.github/workflows/publish-PR-test-results.yml
+++ b/.github/workflows/publish-PR-test-results.yml
@@ -28,9 +28,8 @@ jobs:
               repo: context.repo.repo,
               run_id: ${{ github.event.workflow_run.id }},
             });
-            console.log(artifacts);
             var testArtifact = artifacts.data.artifacts.filter((artifact) => {
-              return artifact.name == "test_results"
+              return artifact.name == "test-results"
             })[0];
             var download = await github.rest.actions.downloadArtifact({
               owner: context.repo.owner,


### PR DESCRIPTION
i hope this fixes the ['id' not found error](https://github.com/hikogui/hikogui/actions/runs/3981806439/jobs/6825786061#step:3:29). 
sorry, i didn't see that "test_results" != "test-result".
removed debug output via console.log()

json dataset: https://api.github.com/repos/hikogui/hikogui/actions/runs/3979959741/artifacts
(`artifacts.name` needs to equal [artifact upload name](https://github.com/hikogui/hikogui/blob/main/.github/workflows/build-on-windows.yml#L157))

