### PR TITLE
setup vscode extension recommendations

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,25 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=827846
+    // for the documentation about the extensions.json format.
+    //
+    // Please set "extensions.ignoreRecommendations": false
+    // in settings.json to get our extension suggestions.
+    //
+    "recommendations": [
+        // EditorConfig
+        "EditorConfig.EditorConfig",
+        // Git + Github
+        "GitHub.vscode-pull-request-github",
+        // C++
+        "ms-vscode.cpptools",
+        "ms-vscode.cpptools-extension-pack",
+        "ms-vscode.cpptools-themes",
+        // CMake
+        "ms-vscode.cmake-tools",
+        "twxs.cmake",
+        // Testing
+        "matepek.vscode-catch2-test-adapter",
+        "ms-vscode.test-adapter-converter",
+        "hbenl.vscode-test-explorer"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,6 +16,7 @@
     "editor.fontSize": 16,
     "terminal.integrated.fontSize": 14,
     "editor.fontLigatures": true,
+    "extensions.ignoreRecommendations": true,
     "files.associations": {
         "new": "cpp",
         "unordered_map": "cpp",

--- a/docs/build_with_visual_studio_code.md
+++ b/docs/build_with_visual_studio_code.md
@@ -28,6 +28,21 @@ For the best experience install Visual Studio before Visual Studio Code.
    - Test Adapter Convert (Microsoft)
    - Test Explorer UI (Holger Benl)
 
+Setup Visual Studio
+-------------------
+
+We offer a curated list of required Visual Studio components in `.github\.vsconfig`.
+You can import this file using the Visual Studio Installer.
+
+Setup VSCode
+------------
+
+We offer a curated list of C++ project extensions in `.vscode\extensions.json`.
+To activate automatic installation of these recommendations,
+modify `"extensions.ignoreRecommendations"` to `false` in your `.vscode\settings.json`.
+This will allow receiving our extension suggestions.
+After installation, you might want to set it back to `true` to avoid
+continuous recommendation notifications during development.
 
 Clone the HikoGUI project from github
 -------------------------------------


### PR DESCRIPTION
This adds `.vscode\extensions.json`, which contains a list of recommended extensions for Visual Studio Code (VSCode). It also includes the addition of `"extensions.ignoreRecommendations"` to `.vscode\settings.json` with the default setting of true (ignore) to prevent notifications during development.

Lastly, the documentation has been updated to instruct users of the library to utilize .vsconfig for configuring Microsoft Visual Studio (MSVC) and enabling recommendations in VSCode.