### PR TITLE
fixed changelog, enabled coverage, tweaked presets

### DIFF
--- a/.github/workflows/build-on-windows.yml
+++ b/.github/workflows/build-on-windows.yml
@@ -163,7 +163,7 @@ jobs:
           path: test_results_*.xml
 
       - name: 📑 Generate CodeCoverage Report (Debug)
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && contains(matrix.config.PRESET, 'deb')
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && contains(matrix.config.PRESET, 'dbg')
         run: |
           curl -L -O https://github.com/OpenCppCoverage/OpenCppCoverage/releases/download/release-0.9.9.0/OpenCppCoverageSetup-x64-0.9.9.0.exe
           OpenCppCoverageSetup-x64-0.9.9.0.exe /VERYSILENT /DIR=.\bin\coverage
@@ -178,7 +178,7 @@ jobs:
           -- ctest.exe
 
       - name: 📦 🚀 Upload CodeCoverage Report to codecov.io (Debug)
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && contains(matrix.config.PRESET, 'deb')
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && contains(matrix.config.PRESET, 'dbg')
         uses: codecov/codecov-action@v3 # https://github.com/codecov/codecov-action
         with:
           files: ./hikogui_coverage.xml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -210,7 +210,8 @@ The first public release.
 
 <!-- Section for Reference Links -->
 
-[Unreleased]: https://github.com/hikogui/hikogui/compare/v0.7.0...HEAD
+[Unreleased]: https://github.com/hikogui/hikogui/compare/v0.8.0...HEAD
+[0.8.0]: https://github.com/hikogui/hikogui/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/hikogui/hikogui/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/hikogui/hikogui/compare/v0.5.1...v0.6.0
 [0.5.1]: https://github.com/hikogui/hikogui/compare/v0.5.0...v0.5.1

--- a/CMake/CPUID.cmake
+++ b/CMake/CPUID.cmake
@@ -31,7 +31,7 @@ set(CPUINFO_SOURCE_FILE
 #include <string>
 #include <fstream>
 #include <sstream>
-#ifdef _WIN32
+#ifdef WIN32
 #include <intrin.h>
 #else
 #include <cpuid.h>

--- a/CMake/CPUID.cmake
+++ b/CMake/CPUID.cmake
@@ -13,7 +13,7 @@ include (CMakePushCheckState)
 cmake_push_check_state ()
 
 if(NOT WIN32)
-  set(CMAKE_REQUIRED_FLAGS "-std=c++11")
+  set(CMAKE_REQUIRED_FLAGS "-std=c++11 -lstdc++")
 else()
 # /EHsc catches C++ exceptions only and tells the compiler to assume that
 # extern C functions never throw a C++ exception.
@@ -31,7 +31,7 @@ set(CPUINFO_SOURCE_FILE
 #include <string>
 #include <fstream>
 #include <sstream>
-#ifdef WIN32
+#ifdef _WIN32
 #include <intrin.h>
 #else
 #include <cpuid.h>

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -22,6 +22,11 @@
                 "microsoft.com/VisualStudioSettings/CMake/1.0": {
                     "hostOS": [ "Windows" ]
                 }
+            },
+            "condition": {
+              "type": "equals",
+              "lhs": "${hostSystemName}",
+              "rhs": "Windows"
             }
         },
         {
@@ -29,8 +34,7 @@
             "hidden": true,
             "inherits": "x64-windows",
             "cacheVariables": {
-                "CMAKE_CXX_COMPILER": "cl",
-                "CMAKE_C_COMPILER": "cl"
+                "CMAKE_CXX_COMPILER": "cl"
             },
             "vendor": {
                 "microsoft.com/VisualStudioSettings/CMake/1.0": {
@@ -39,12 +43,11 @@
             }
         },
         {
-            "name": "clang-x64-windows",
+            "name": "clangcl-x64-windows",
             "hidden": true,
             "inherits": "x64-windows",
             "cacheVariables": {
-                "CMAKE_CXX_COMPILER": "clang-cl",
-                "CMAKE_C_COMPILER": "clang-cl"
+                "CMAKE_CXX_COMPILER": "clang-cl"
             },
             "vendor": {
                 "microsoft.com/VisualStudioSettings/CMake/1.0": {
@@ -62,9 +65,9 @@
             }
         },
         {
-            "name": "clang-x64-windows-static",
+            "name": "clangcl-x64-windows-static",
             "hidden": true,
-            "inherits": "clang-x64-windows",
+            "inherits": "clangcl-x64-windows",
             "cacheVariables": {
                 "VCPKG_TARGET_TRIPLET": "x64-windows-static",
                 "BUILD_SHARED_LIBS": "OFF"
@@ -81,7 +84,7 @@
         },
         {
             "name": "vc17-x64-windows-static-dbg",
-            "displayName": "MSVC-x64-Debug",
+            "displayName": "MSVC-Debug",
             "inherits": "vc17-x64-windows-static",
             "cacheVariables": {
                 "CMAKE_BUILD_TYPE": "Debug"
@@ -90,7 +93,7 @@
         {
             "name": "vc17-x64-windows-static-dbg-asan",
             "hidden": true,
-            "displayName": "MSVC-x64-Debug (ASAN)",
+            "displayName": "MSVC-Debug (ASAN)",
             "inherits": "vc17-x64-windows-static-dbg",
             "cacheVariables": {
                 "HI_ENABLE_ASAN": "ON"
@@ -98,7 +101,7 @@
         },
         {
             "name": "vc17-x64-windows-static-rel",
-            "displayName": "MSVC-x64-Release",
+            "displayName": "MSVC-Release",
             "inherits": "vc17-x64-windows-static",
             "cacheVariables": {
                 "CMAKE_BUILD_TYPE": "Release"
@@ -106,40 +109,48 @@
         },
         {
             "name": "vc17-x64-windows-static-rdi",
-            "displayName": "MSVC-x64-RelWithDebInfo",
+            "displayName": "MSVC-RelWithDebInfo",
             "inherits": "vc17-x64-windows-static",
             "cacheVariables": {
                 "CMAKE_BUILD_TYPE": "RelWithDebInfo"
             }
         },
         {
-            "name": "clang-x64-windows-static-dbg",
-            "displayName": "ZZ clang-x64-Debug",
-            "inherits": "clang-x64-windows-static",
+            "name": "clangcl-x64-windows-static-dbg",
+            "displayName": "ClangCL-Debug",
+            "inherits": "clangcl-x64-windows-static",
             "cacheVariables": {
                 "CMAKE_BUILD_TYPE": "Debug"
             }
         },
         {
             "name": "vc17-x64-windows-static-rel-ci",
-            "displayName": "ZZ MSVC-x64-Release (for CI)",
+            "displayName": "MSVC-Release (for CI)",
             "inherits": "vc17-x64-windows-static-rel",
             "binaryDir": "build",
+            "installDir": "install",
             "cacheVariables": {
-                "CMAKE_INSTALL_PREFIX": "install",
-                "CMAKE_C_COMPILER_LAUNCHER": "sccache",
                 "CMAKE_CXX_COMPILER_LAUNCHER": "sccache"
+            },
+            "condition": {
+              "type": "equals",
+              "lhs": "$env{CI}",
+              "rhs": "true"
             }
         },
         {
             "name": "vc17-x64-windows-static-dbg-ci",
-            "displayName": "ZZ MSVC-x64-Debug (for CI)",
+            "displayName": "MSVC-Debug (for CI)",
             "inherits": "vc17-x64-windows-static-dbg",
             "binaryDir": "build",
+            "installDir": "install",
             "cacheVariables": {
-                "CMAKE_INSTALL_PREFIX": "install",
-                "CMAKE_C_COMPILER_LAUNCHER": "sccache",
                 "CMAKE_CXX_COMPILER_LAUNCHER": "sccache"
+            },
+            "condition": {
+              "type": "equals",
+              "lhs": "$env{CI}",
+              "rhs": "true"
             }
         }
     ],

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -34,7 +34,8 @@
             "hidden": true,
             "inherits": "x64-windows",
             "cacheVariables": {
-                "CMAKE_CXX_COMPILER": "cl"
+                "CMAKE_CXX_COMPILER": "cl",
+                "CMAKE_C_COMPILER": "cl"
             },
             "vendor": {
                 "microsoft.com/VisualStudioSettings/CMake/1.0": {
@@ -47,7 +48,8 @@
             "hidden": true,
             "inherits": "x64-windows",
             "cacheVariables": {
-                "CMAKE_CXX_COMPILER": "clang-cl"
+              "CMAKE_CXX_COMPILER": "clang-cl",
+              "CMAKE_C_COMPILER": "clang-cl"
             },
             "vendor": {
                 "microsoft.com/VisualStudioSettings/CMake/1.0": {

--- a/docs/release_checklist.md
+++ b/docs/release_checklist.md
@@ -4,7 +4,7 @@ Release Checklist
  * Create code name at <https://killercup.github.io/codenamer/> "English Adjectives" "Animals" Alliterate
  * In hikogui/hikogui:
    - Create release branch
-   - Add entry to CHANGELOG.md 
+   - Add entry to CHANGELOG.md and update link section at end of file
    - Update version in vcpkg.json
    - (Possibly test and fix hikogui-hello-world in local mode).
    - Merge into main (needed for hikogui/hikogui\_hello\_world test builds)
@@ -17,7 +17,8 @@ Release Checklist
    - Check if pull request builds on CI.
  * Make release of hikogui/hikogui
    - Copy the release description from CHANGELOG.md
- * In hikogui/hikogui.github.io Run the "Documentation Pipeline"
+ * In hikogui/hikogui.github.io:
+   - Run the "Documentation Pipeline" workflow
  * In hikogui/vcpkg
    - Update ports/hikogui/vcpkg.json
    - Update ports/hikogui/portfile.cmake (update REF, set SHA512 to 0)


### PR DESCRIPTION
- enable code-coverage steps on CI
- fix links for v0.8.0 in Changelog.md and add reminder to release_checklist.md
- remove "-x64" from displayNames (displayed is now only COMPILER-BUILDTYPE)
- add condition check for env var CI to CI presets, so that they are now automatically hidden on non-CI systems
- changed from CMAKE_INSTALL_PREFIX to installDir on CI presets
- add condition to show the windows presets only on windows = hide windows presets on linux
- removed CMAKE_C_COMPILER_LAUNCHER and CMAKE_C_COMPILER directives, both trigger unused CMAKE directive warning
- renamed the MSVC clang targets to "clangcl" to make room for LLVM clang
- fixed compilation of CPUINFO.cmake with Clang17