### PR TITLE
fix selection box

### DIFF
--- a/src/hikogui/widgets/overlay_widget.hpp
+++ b/src/hikogui/widgets/overlay_widget.hpp
@@ -94,6 +94,7 @@ public:
         _content_constraints = _content->update_constraints();
         return _content_constraints;
     }
+
     void set_layout(widget_layout const& context) noexcept override
     {
         _layout = context;
@@ -107,6 +108,7 @@ public:
         // The content should not draw in the border of the overlay, so give a tight clipping rectangle.
         _content->set_layout(_layout.transform(_content_shape, context.rectangle()));
     }
+
     void draw(draw_context const& context) noexcept override
     {
         if (mode() > widget_mode::invisible) {
@@ -116,19 +118,23 @@ public:
             _content->draw(context);
         }
     }
+
     [[nodiscard]] color background_color() const noexcept override
     {
         return theme().color(semantic_color::fill, _layout.layer + 1);
     }
+
     [[nodiscard]] color foreground_color() const noexcept override
     {
         return theme().color(semantic_color::border, _layout.layer + 1);
     }
+
     void scroll_to_show(hi::aarectangle rectangle) noexcept override
     {
         // An overlay is in an absolute position on the window,
         // so do not forward the scroll_to_show message to its parent.
     }
+
     [[nodiscard]] hitbox hitbox_test(point2 position) const noexcept override
     {
         hi_axiom(loop::main().on_thread());
@@ -138,6 +144,12 @@ public:
         } else {
             return {};
         }
+    }
+
+    bool handle_event(gui_event const& event) noexcept override
+    {
+        // Short-cut event handling, no-events should be passed below the overlay.
+        return true;
     }
     /// @endprivatesection
 private:

--- a/src/hikogui/widgets/selection_delegate.hpp
+++ b/src/hikogui/widgets/selection_delegate.hpp
@@ -58,14 +58,14 @@ public:
         return size(sender) == 0;
     }
 
-    /** Make a widget to be displayed in a selection pull-down.
+    /** Create a new widget that represents the button in the selection menu.
      *
-     * @note It is undefined behavior if the index is beyond the end of the number of options.
-     * @param sender The parent widget that will become the owner.
-     * @param index The index in the list of options.
-     * @return The widgets to be displayed.
+     * @param sender The selection widget that uses this delegate.
+     * @param parent The parent widget of the new widget being created.
+     * @param index The index of the option.
+     * @return A new widget that represents the option at @a index. 
      */
-    [[nodiscard]] virtual std::unique_ptr<widget> make_option_widget(widget_intf const& sender, size_t index) noexcept = 0;
+    [[nodiscard]] virtual std::unique_ptr<widget> make_option_widget(widget_intf const& sender, widget_intf const &parent, size_t index) noexcept = 0;
 
     /** Get the label of the selected option.
      *
@@ -150,10 +150,17 @@ public:
         return _option_delegate->keyboard_focus_id();
     }
 
-    [[nodiscard]] std::unique_ptr<widget> make_option_widget(widget_intf const& sender, size_t index) noexcept override
+    /** Create a new widget that represents the button in the selection menu.
+     *
+     * @param sender The selection widget that uses this delegate.
+     * @param parent The parent widget of the new widget being created.
+     * @param index The index of the option.
+     * @return A new widget that represents the option at @a index. 
+     */
+    [[nodiscard]] std::unique_ptr<widget> make_option_widget(widget_intf const& sender, widget_intf const &parent, size_t index) noexcept override
     {
         auto& [option_value, option_label] = options->at(index);
-        return _option_delegate->make_option_widget(sender, option_value, option_label, _option_delegate);
+        return _option_delegate->make_option_widget(sender, parent, option_value, option_label, _option_delegate);
     }
 
 private:
@@ -200,14 +207,14 @@ private:
         }
 
         [[nodiscard]] std::unique_ptr<widget>
-        make_option_widget(widget_intf const& sender, value_type const& value, label const& label, std::shared_ptr<option_delegate_type> shared_this) noexcept
+        make_option_widget(widget_intf const& sender, widget_intf const &parent, value_type const& value, label const& label, std::shared_ptr<option_delegate_type> shared_this) noexcept
         {
             using button_widget = radio_menu_button_widget;
             using button_attributes = radio_menu_button_widget::attributes_type;
 
             // Prepare the value for the next widget, so that the widget immediately can retrieve its value.
             _next_value = value;
-            return make_unique<button_widget>(make_not_null(sender), button_attributes{label}, std::move(shared_this));
+            return make_unique<button_widget>(make_not_null(parent), button_attributes{label}, std::move(shared_this));
         }
 
         [[nodiscard]] widget_value state(widget_intf const& sender) const noexcept override

--- a/src/hikogui/widgets/selection_widget.hpp
+++ b/src/hikogui/widgets/selection_widget.hpp
@@ -445,7 +445,7 @@ private:
     {
         _grid_widget->clear();
         for (auto i = 0_uz; i != delegate->size(*this); ++i) {
-            _grid_widget->push_bottom(delegate->make_option_widget(*this, i));
+            _grid_widget->push_bottom(delegate->make_option_widget(*this, *_grid_widget, i));
         }
 
         ++global_counter<"selection_widget:update_options:constrain">;


### PR DESCRIPTION
This patch fixes two bugs.

# Scrolling the selection box caused the selection box to disappear.
The event for button-up was not handled by the scroll-bar and instead was chained to the ancestor the selection button which closed the selection box in response.

This was solved by shortcutting any events in the overlay widget, so that no events would go deeper.

# Using the scroll wheel on the selection box menu buttons would cause the wrong view to scroll.
The buttons where parented on the selection-widget instead of the grid-widget that was holding those buttons.

Changed the selection-delegate to accept a parent for the widgets, so that the grid-widget now can become the parent. This solved a lot of weird issues with the selection buttons.
