### PR TITLE
update image to "bookworm-with-vulkansdk-1.0.4"

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
     "name": "HikoGui DevBox",
-    "image": "ghcr.io/jakoch/cpp-devbox:with-vulkansdk-latest",
+    "image": "ghcr.io/jakoch/cpp-devbox:bookworm-with-vulkansdk-1.0.4",
     "customizations": {
         "vscode": {
             "extensions": [


### PR DESCRIPTION
This updates the cpp-devbox image by using the new versioning scheme. 
The new scheme supports two Debian versions: Bookworm and Trixie, each with and without Vulkan-SDK. 
Here it utilizes the stable Bookworm image with Vulkan-SDK included 
and transitions from using the rolling release (latest) to a fixed version (1.0.4).

The following version are included:

```
# cpp-devbox:bookworm-with-vulkansdk-1.0.4 (2024-07-04) 

Debian Version: 12 Bookworm

## Version Overview

GCC         12.2.0, 13.2.0
Clang       17.0.6
Vulkan-SDK  1.3.283.0
Ninja       1.11.1
cmake       3.30.0
ccache      4.10.1
vcpkg       2024-06-10-02590c43
Mold        2.32.1
ldd         2.36
lldb        17.0.6
valgrind    3.19.0
cppcheck    2.10
git         2.39.2
```